### PR TITLE
Resolve localized strings to best value

### DIFF
--- a/arches_querysets/utils/datatype_transforms.py
+++ b/arches_querysets/utils/datatype_transforms.py
@@ -147,6 +147,21 @@ def string_to_json(self, tile, node):
         return self.compile_json(tile, node, **data.get(str(node.nodeid)) or {})
 
 
+def string_to_representation(self, value):
+    """Resolve localized string metadata to a single language value."""
+    if not value or not isinstance(value, dict):
+        return ""
+    lang_val_pairs = [(lang, obj["value"]) for lang, obj in value.items()]
+    if not lang_val_pairs:
+        return
+    ranked = sorted(
+        lang_val_pairs,
+        key=lambda pair: rank_label(source_lang=pair[0]),
+        reverse=True,
+    )
+    return ranked[0][1]
+
+
 def date_transform_value_for_tile(self, value, **kwargs):
     value = None if value == "" else value
     if value is not None:

--- a/arches_querysets/utils/datatype_transforms.py
+++ b/arches_querysets/utils/datatype_transforms.py
@@ -104,6 +104,7 @@ def concept_list_to_json(self, tile, node):
 def file_list_transform_value_for_tile(self, value, *, languages, **kwargs):
     if not value:
         return value
+    # TODO: this should probably delegate more to self.transform_value_for_tile()
     final_value = copy.deepcopy(value)
     for file_info in final_value:
         for key, val in file_info.items():
@@ -120,6 +121,21 @@ def file_list_transform_value_for_tile(self, value, *, languages, **kwargs):
                     }
 
     return final_value
+
+
+def file_list_merge_tile_value(self, tile, node_id_str, transformed) -> None:
+    if not (existing_tile_value := tile.data.get(node_id_str)):
+        tile.data[node_id_str] = transformed
+        return
+    for file_info in transformed:
+        for key, val in file_info.items():
+            if key not in {"altText", "attribution", "description", "title"}:
+                continue
+            for existing_file_info in existing_tile_value:
+                if existing_file_info.get("file_id") == file_info.get("file_id"):
+                    file_info[key] = existing_file_info[key] | val
+                break
+    tile.data[node_id_str] = transformed
 
 
 def file_list_to_representation(self, value):
@@ -145,6 +161,10 @@ def string_to_json(self, tile, node):
     data = self.get_tile_data(tile)
     if data:
         return self.compile_json(tile, node, **data.get(str(node.nodeid)) or {})
+
+
+def string_merge_tile_value(self, tile, node_id_str, transformed) -> None:
+    tile.data[node_id_str] = tile.data.get(node_id_str, {}) | transformed
 
 
 def string_to_representation(self, value):


### PR DESCRIPTION
Closes #3 

Also hardens file-list metadata processing.

`StringDataType.transform_value_for_tile()` was already smart enough to process incoming strings, but it didn't preserve existing values in other languages, which I'm assuming we'll need if we're not exchanging the full dict of values every time. If someone really wants to overwrite all values, they can post back a dict.