### PR TITLE
Provide simple serialization without DRF

### DIFF
--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,85 @@
+from arches.app.models.models import Node, TileModel
+from arches.app.utils.betterJSONSerializer import JSONDeserializer, JSONSerializer
+from arches_querysets.models import SemanticResource
+from tests.utils import GraphTestCase
+
+
+class SerializationTests(GraphTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # Create child nodegroups and tiles.
+        cls.nodegroup_1_child, _ = cls.create_nodegroup(
+            "datatypes_1_child", "1", parent_nodegroup=cls.nodegroup_1
+        )
+        cls.nodegroup_n_child, _ = cls.create_nodegroup(
+            "datatypes_n_child", "n", parent_nodegroup=cls.nodegroup_n
+        )
+        cls.cardinality_1_child_tile = TileModel.objects.create(
+            nodegroup=cls.nodegroup_1_child,
+            resourceinstance=cls.resource_42,
+            data={},
+            parenttile=cls.cardinality_1_tile,
+        )
+        cls.cardinality_n_child_tile = TileModel.objects.create(
+            nodegroup=cls.nodegroup_n_child,
+            resourceinstance=cls.resource_42,
+            data={},
+            parenttile=cls.cardinality_n_tile,
+        )
+
+        # Clone nodes.
+        for node in cls.nodes:
+            node.pk = None
+            node.name = node.name + "-child"
+            node.alias = node.alias + "_child"
+            node.nodegroup = (
+                cls.nodegroup_1_child
+                if node.nodegroup == cls.nodegroup_1
+                else cls.nodegroup_n_child
+            )
+        Node.objects.bulk_create(cls.nodes)
+
+        # Create data for the child non-localized-string node only.
+        # TileModel.save() will initialize the other nodes to None.
+        cls.non_localized_string_child_node = Node.objects.get(
+            alias="non_localized_string_child"
+        )
+        cls.non_localized_string_child_node_n = Node.objects.get(
+            alias="non_localized_string_n_child"
+        )
+        cls.cardinality_1_child_tile.data = {
+            str(cls.non_localized_string_child_node): "child-1-value",
+        }
+        cls.cardinality_1_child_tile.save()
+        cls.cardinality_n_child_tile.data = {
+            str(cls.non_localized_string_child_node_n): "child-n-value",
+        }
+        cls.cardinality_n_child_tile.save()
+
+        cls.resource = SemanticResource.as_model(
+            "datatype_lookups", as_representation=True
+        ).get(pk=cls.resource_42.pk)
+
+    def test_serialization_via_better_json_serializer(self):
+        dict_string = JSONSerializer().serialize(self.resource)
+        resource_dict = JSONDeserializer().deserialize(dict_string)
+        # Django model fields are present.
+        self.assertIn("graph_id", resource_dict)
+        tile_dict = resource_dict["aliased_data"]["datatypes_1"]
+        self.assertIn("nodegroup_id", tile_dict)
+        # Node values are present.
+        self.assertIn("non_localized_string", tile_dict["aliased_data"])
+        # Special properties are not present.
+        self.assertNotIn("data", tile_dict)
+        self.assertNotIn("parent", tile_dict)
+
+        # Child tiles appear under nodegroup aliases.
+        child_tile_dict = tile_dict["aliased_data"]["datatypes_1_child"]
+        self.assertIn("tileid", child_tile_dict)
+
+        # Cardinality N tiles appear in an array.
+        tile_list = resource_dict["aliased_data"]["datatypes_n"][0]
+        child_tile_list = tile_list["aliased_data"]["datatypes_n_child"]
+        self.assertIn("tileid", child_tile_list[0])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -44,29 +44,26 @@ class GraphTestCase(TestCase):
         )
 
     @classmethod
-    def create_nodegroups_and_grouping_nodes(cls):
-        cls.grouping_node_1 = Node(
-            graph=cls.graph, alias="datatypes_1", istopnode=False, datatype="semantic"
+    def create_nodegroup(cls, alias, cardinality, parent_nodegroup=None):
+        grouping_node = Node(
+            graph=cls.graph, alias=alias, istopnode=False, datatype="semantic"
         )
-        cls.nodegroup_1 = NodeGroup.objects.create(pk=cls.grouping_node_1.pk)
+        nodegroup = NodeGroup.objects.create(
+            pk=grouping_node.pk,
+            cardinality=cardinality,
+            parentnodegroup=parent_nodegroup,
+        )
         if arches_version >= (8, 0):
-            cls.nodegroup_1.grouping_node = cls.grouping_node_1
-            cls.nodegroup_1.save()
-        cls.grouping_node_1.nodegroup = cls.nodegroup_1
-        cls.grouping_node_1.save()
+            nodegroup.grouping_node = grouping_node
+            nodegroup.save()
+        grouping_node.nodegroup = nodegroup
+        grouping_node.save()
+        return nodegroup, grouping_node
 
-        cls.grouping_node_n = Node(
-            graph=cls.graph, alias="datatypes_n", istopnode=False, datatype="semantic"
-        )
-        cls.nodegroup_n = NodeGroup.objects.create(
-            pk=cls.grouping_node_n.pk,
-            cardinality="n",
-        )
-        if arches_version >= (8, 0):
-            cls.nodegroup_n.grouping_node = cls.grouping_node_n
-            cls.nodegroup_n.save()
-        cls.grouping_node_n.nodegroup = cls.nodegroup_n
-        cls.grouping_node_n.save()
+    @classmethod
+    def create_nodegroups_and_grouping_nodes(cls):
+        cls.nodegroup_1, cls.grouping_node_1 = cls.create_nodegroup("datatypes_1", "1")
+        cls.nodegroup_n, cls.grouping_node_n = cls.create_nodegroup("datatypes_n", "n")
 
     @classmethod
     def create_data_collecting_nodes(cls):
@@ -148,10 +145,12 @@ class GraphTestCase(TestCase):
         cls.resource_42 = ResourceInstance.objects.create(
             graph=cls.graph,
             descriptors={"en": {"name": "Resource referencing 42"}},
+            name="Resource referencing 42",
         )
         cls.resource_none = ResourceInstance.objects.create(
             graph=cls.graph,
             descriptors={"en": {"name": "Resource referencing None"}},
+            name="Resource referencing None",
         )
 
     @classmethod


### PR DESCRIPTION
Make the aliased data wrappers play nicely with our `JSONSerializer`:
- They were getting ignored since they existed on a Django model but they weren't fields or properties
- Making them properties is a nice code discoverability win (instead of being invented in thin air only in querysets.py)
