### PR TITLE
Add basic usage example, update readme

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -29,7 +29,7 @@ runs:
     - name: Install Python packages
       run: |
         python -m pip install --upgrade pip
-        pip install . --group dev
+        pip install '.[drf]' --group dev
         echo Python packages installed
       shell: bash
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Vary: Accept
                         ...
 ```
 </details>
+
 - At the bottom of the page, switch to the JSON view to edit the payload and save back. (You can also provide interchange
 values directly rather than wrapping them under an `interchange_value` key.)
 - The schema for the interchange value is [tested here](https://github.com/archesproject/arches-querysets/blob/main/tests/test_datatypes.py).

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Factors differentiating the arches-querysets approach include:
 
 As the API stabilizes, elements may be proposed for inclusion in archesproject/arches as ready.
 
-The initial goal is for the first release to support both Arches 7.6 and 8.0.
+The first version supports both Arches 7.6 and 8.0.
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Factors differentiating the arches-querysets approach include:
     - can leverage other built-in Django features:
         - pagination
         - migrations
-        - admin
+        - registering custom SQL lookups
 - Reduce drift against core Arches development: validation traffic still routed through core arches
 - Fully dynamic:
     - does not require declaring "well-known" models

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 ## arches-querysets
 
-A Django-native interface for expressing application logic,
-querying business data, or building APIs using node and nodegroup aliases.
+A Django-native interface for Arches implementers to express application logic,
+query business data, or build APIs using node and nodegroup aliases.
+
+Please see the [project page](http://archesproject.org/) for more information on the Arches project.
 
 ### Installation
 The optional API integration with Django REST Framework is included below.
@@ -30,6 +32,8 @@ urlpatterns = [
     *arches_rest_framework_urls,
 ]
 ```
+
+For developer install instructions, see the [Developer Setup](#developer-setup-for-contributing-to-the-arches-querysets-project) section below.
 
 ### Quickstart
 ```shell
@@ -230,3 +234,71 @@ Contributions and bug reports are welcome!
 ### Thanks
 
 We are grateful to members of the Arches community that have shared prior work in this area: in particular, the approaches linked in the [precedents](#how-does-this-compare-to-other-approaches).
+
+### Developer Setup (for contributing to the Arches Querysets project)
+
+1. Download the arches-querysets repo:
+
+    a.  If using the [Github CLI](https://cli.github.com/): `gh repo clone archesproject/arches-querysets`
+    
+    b.  If not using the Github CLI: `git clone https://github.com/archesproject/arches-querysets.git`
+
+2. Download the arches package:
+
+    a.  If using the [Github CLI](https://cli.github.com/): `gh repo clone archesproject/arches`
+
+    b.  If not using the Github CLI: `git clone https://github.com/archesproject/arches.git`
+
+3. Create a virtual environment outside of both repositories: 
+    ```
+    python3 -m venv ENV
+    ```
+
+4. Activate the virtual enviroment in your terminal:
+    ```
+    source ENV/bin/activate
+    ```
+
+5. Navigate to the `arches-querysets` directory, and install the project (with optional and development dependencies):
+    ```
+    cd arches-querysets
+    pip install -e '.[drf]' --group dev
+    ```
+
+6. Also install core arches for local development:
+    ```
+    pip install -e ../arches
+    ```
+
+7. Run the Django server:
+    ```
+    python manage.py runserver
+    ```
+
+## Committing changes
+
+NOTE: Changes are committed to the arches-querysets repository. 
+
+1. Navigate to the repository
+    ```
+    cd arches-querysets
+    ```
+
+2. Cut a new git branch
+    ```
+    git checkout origin/main -b my-descriptive-branch-name
+    ```
+
+3. Add your changes to the current git commit
+    ```
+    git status
+    git add -- path/to/file path/to/second/file
+    git commit -m "Descriptive commit message"
+    ```
+
+4. Update the remote repository with your commits:
+    ```
+    git push origin HEAD
+    ```
+
+5. Navigate to https://github.com/archesproject/arches-querysets/pulls to see and commit the pull request.

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ AliasedData(string={'en': {'direction': 'ltr', 'value': 'forty-two'}},
 
 In [3]: result.aliased_data.datatypes_1.aliased_data.string = 'new value'
 
-In [4]: result.save()
+In [4]: result.save(index=False)  # indexing avoided purely for 7.6/8.0 test data compat
 ```
 
 ### How would this help an Arches developer?

--- a/arches_querysets/datatypes/concept_types.py
+++ b/arches_querysets/datatypes/concept_types.py
@@ -1,6 +1,7 @@
 import uuid
 
 from arches.app.datatypes import concept_types
+from arches.app.models.models import Value
 from arches.app.utils.betterJSONSerializer import JSONDeserializer, JSONSerializer
 
 
@@ -8,6 +9,8 @@ class ConceptDataType(concept_types.ConceptDataType):
     def transform_value_for_tile(self, value, **kwargs):
         if isinstance(value, dict) and (value_id := value.get("valueid")):
             return super().transform_value_for_tile(value_id)
+        if isinstance(value, Value):
+            return super().transform_value_for_tile(str(value.pk))
         return super().transform_value_for_tile(value)
 
     def to_python(self, value, **kwargs):

--- a/arches_querysets/rest_framework/generic_views.py
+++ b/arches_querysets/rest_framework/generic_views.py
@@ -1,4 +1,7 @@
+from django.conf import settings
+
 from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.parsers import JSONParser
 
 from arches_querysets.rest_framework.multipart_json_parser import MultiPartJSONParser
@@ -14,6 +17,8 @@ class ArchesResourceListCreateView(ArchesModelAPIMixin, ListCreateAPIView):
     permission_classes = [ResourceEditor | ReadOnly]
     serializer_class = ArchesResourceSerializer
     parser_classes = [JSONParser, MultiPartJSONParser]
+    pagination_class = LimitOffsetPagination
+    page_size = settings.API_MAX_PAGE_SIZE
 
 
 class ArchesResourceDetailView(ArchesModelAPIMixin, RetrieveUpdateDestroyAPIView):
@@ -26,6 +31,8 @@ class ArchesTileListCreateView(ArchesModelAPIMixin, ListCreateAPIView):
     permission_classes = [ResourceEditor | ReadOnly]
     serializer_class = ArchesTileSerializer
     parser_classes = [JSONParser, MultiPartJSONParser]
+    pagination_class = LimitOffsetPagination
+    page_size = settings.API_MAX_PAGE_SIZE
 
 
 class ArchesTileDetailView(ArchesModelAPIMixin, RetrieveUpdateDestroyAPIView):

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -217,6 +217,10 @@ class TileAliasedDataSerializer(serializers.ModelSerializer, NodeFetcherMixin):
         self._root_node = kwargs.pop("root_node", None)
         super().__init__(instance, data, **kwargs)
         self._child_nodegroup_aliases = []
+        if not self.url_field_name:
+            # Avoid cryptic errors in case a node alias collides with
+            # DRF's default URL field name ("url")
+            self.url_field_name = "__nonexistent__"
 
     def __deepcopy__(self, memo):
         ret = super().__deepcopy__(memo)

--- a/arches_querysets/urls.py
+++ b/arches_querysets/urls.py
@@ -3,8 +3,40 @@ from django.conf.urls.static import static
 from django.conf.urls.i18n import i18n_patterns
 from django.urls import include, path
 
+from arches_querysets.apps import ArchesQuerySetsConfig
+from arches_querysets.rest_framework.generic_views import (
+    ArchesResourceDetailView,
+    ArchesResourceListCreateView,
+    ArchesTileDetailView,
+    ArchesTileListCreateView,
+)
+
+app_name = ArchesQuerySetsConfig.name
+arches_rest_framework_urls = [
+    path(
+        "api/resource/<slug:graph>",
+        ArchesResourceListCreateView.as_view(),
+        name="api-resources",
+    ),
+    path(
+        "api/resource/<slug:graph>/<uuid:pk>",
+        ArchesResourceDetailView.as_view(),
+        name="api-resource",
+    ),
+    path(
+        "api/tile/<slug:graph>/<slug:nodegroup_alias>",
+        ArchesTileListCreateView.as_view(),
+        name="api-tiles",
+    ),
+    path(
+        "api/tile/<slug:graph>/<slug:nodegroup_alias>/<uuid:pk>",
+        ArchesTileDetailView.as_view(),
+        name="api-tile",
+    ),
+]
+
 urlpatterns = [
-    # project-level urls
+    *arches_rest_framework_urls,
 ]
 
 # handler400 = "arches.app.views.main.custom_400"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,11 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
     "arches>=7.6.12,<8.1.0,!=8.0.0",
-    "djangorestframework==3.16.0",
 ]
 version = "0.2.0-dev"
+
+[project.optional-dependencies]
+drf = ["djangorestframework~=3.16"]
 
 [project.urls]
 Homepage = "https://archesproject.org/"


### PR DESCRIPTION
Happy to add additional items to make this a little more like the other projects if we want.

Closes #20
- Provide a namespaced set of routes
- Add basic usage example
- Fix cryptic error for "url" node alias
- Ensure basic usage example works
- Remove need for `REST_FRAMEWORK` setting

The last thing before the release would be to cut a branch and update the version number in pyproject.toml