### PR TITLE
Fix tests on 7.6

### DIFF
--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -82,6 +82,10 @@ class TileTreeOperation:
         from arches_querysets.models import ResourceTileTree, TileTree
 
         lookup = {}
+        if not self.entry._permitted_nodes:
+            self.entry._permitted_nodes = Node.objects.filter(
+                nodegroup__in=self.editable_nodegroups
+            )
         if isinstance(self.entry, ResourceTileTree):
             for node in self.entry._permitted_nodes:
                 if node.pk == node.nodegroup_id:
@@ -111,9 +115,8 @@ class TileTreeOperation:
         except ProgrammingError as e:
             if e.args and "excess_tiles" in e.args[0]:
                 nodegroup_id = e.args[0].split("nodegroupid: ")[1].split(",")[0]
-                nodegroup_alias = self.grouping_nodes_by_nodegroup_id[
-                    uuid.UUID(nodegroup_id)
-                ].alias
+                uid = uuid.UUID(nodegroup_id)
+                nodegroup_alias = self.grouping_nodes_by_nodegroup_id[uid].alias
                 msg = _("Tile Cardinality Error")
                 raise ValidationError({nodegroup_alias: msg}) from e
             raise

--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -91,10 +91,10 @@ class TileTreeOperation:
                 if node.pk == node.nodegroup_id:
                     lookup[node.pk] = node
         elif isinstance(self.entry, TileTree):
-            # TODO: look into whether this is repetitive.
             for nodegroup in self.nodegroups:
                 if arches_version >= (8, 0):
-                    lookup[nodegroup.pk] = nodegroup.grouping_node
+                    if nodegroup.grouping_node in self.entry._permitted_nodes:
+                        lookup[nodegroup.pk] = nodegroup.grouping_node
                 else:
                     for node in nodegroup.node_set.all():
                         if (

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -437,6 +437,8 @@ class ArchesTileSerializer(serializers.ModelSerializer, NodeFetcherMixin):
             dummy_instance.sortorder = None
             dummy_instance.set_next_sort_order()
             validated_data["sortorder"] = dummy_instance.sortorder
+        if arches_version < (8, 0):
+            validated_data["data"] = {}
         validated_data["__request"] = self.context["request"]
         with transaction.atomic():
             created = super().create(validated_data)

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -63,7 +63,7 @@ class SaveTileTests(GraphTestCase):
     def test_cardinality_error(self):
         with self.assertRaises(ValidationError) as ctx:
             TileTree.objects.create(
-                nodegroup=self.nodegroup_1, resourceinstance=self.resource_42
+                nodegroup=self.nodegroup_1, resourceinstance=self.resource_42, data={}
             )
         self.assertEqual(
             ctx.exception.message_dict, {"datatypes_1": ["Tile Cardinality Error"]}


### PR DESCRIPTION
#41 added a test that failed on 7.6 because on Arches 7.6 there is no model-level default for the `data` column. So I added some version compatibility for that.

Then, the test failed in a way that suggested that some nodegroup permissions checks didn't behave the same way if (`_permitted_nodes` was empty). (Answer: make sure it's not empty).