### PR TITLE
Remove repetitive queries for languages when saving strings

### DIFF
--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -44,7 +44,7 @@ class TileTreeOperation:
         if not self.request:
             self.request = HttpRequest()
         if not getattr(self.request, "user", None):
-            # Allow server-side usage when not going through middlewrae
+            # Allow server-side usage when not going through middleware
             self.request.user = User.objects.get(username="anonymous")
         self.save_kwargs = save_kwargs or {}
         self.transaction_id = uuid.uuid4()

--- a/arches_querysets/datatypes/file.py
+++ b/arches_querysets/datatypes/file.py
@@ -1,14 +1,17 @@
 from django.utils.translation import get_language
 
 from arches.app.datatypes import datatypes
+from arches.app.models import models
 
 
 class FileListDataType(datatypes.FileListDataType):
     localized_metadata_keys = {"altText", "attribution", "description", "title"}
 
-    def transform_value_for_tile(self, value, *, languages, **kwargs):
+    def transform_value_for_tile(self, value, *, languages=None, **kwargs):
         if not value:
             return value
+        if not languages:  # pragma: no cover
+            languages = models.Language.objects.all()
 
         language = get_language()
         stringified_list = ",".join([file_info.get("name") for file_info in value])

--- a/arches_querysets/datatypes/string.py
+++ b/arches_querysets/datatypes/string.py
@@ -1,4 +1,10 @@
+import ast
+import json
+import re
+
 from arches.app.datatypes import datatypes
+from arches.app.models import models
+from django.utils.translation import get_language
 
 
 class StringDataType(datatypes.StringDataType):
@@ -6,3 +12,49 @@ class StringDataType(datatypes.StringDataType):
         if not value or not isinstance(value, dict):
             return None
         return value
+
+    def transform_value_for_tile(self, value, *, languages=None, **kwargs):
+        """
+        Override to:
+        1. avoid refetching languages already present in kwargs.
+        2. get the direction from the database when falling back to get_language().
+        """
+        language = get_language()
+        try:
+            regex = re.compile(r"(.+)\|([A-Za-z-]+)$", flags=re.DOTALL | re.MULTILINE)
+            match = regex.match(value)
+            if match is not None:
+                language = match.groups()[1]
+                value = match.groups()[0]
+        except Exception as e:
+            pass
+
+        try:
+            parsed_value = json.loads(value)
+        except Exception:
+            try:
+                parsed_value = ast.literal_eval(value)
+            except Exception:
+                parsed_value = value
+
+        try:
+            parsed_value.keys()
+            return parsed_value
+        except AttributeError:
+            if languages:
+                for language_object in languages:
+                    if language_object.code == language:
+                        break
+                else:
+                    language_object = None
+            else:
+                language_object = models.Language.objects.filter(code=language).first()
+            if language_object is not None:
+                return {
+                    language: {
+                        "value": value,
+                        "direction": language_object.default_direction,
+                    }
+                }
+
+            return {language: {"value": value, "direction": "ltr"}}


### PR DESCRIPTION
When running datatype methods, an attempt is made to reuse a queryset of `Language` objects instead of constant refetching:

https://github.com/archesproject/arches-querysets/blob/0719dc35a5079cbdb373bef49633d1a41ed3585d/arches_querysets/bulk_operations/tiles.py#L329-L331

https://github.com/archesproject/arches-querysets/blob/0719dc35a5079cbdb373bef49633d1a41ed3585d/arches_querysets/bulk_operations/tiles.py#L339-L341

***
This PR makes use of that in the String data type. It also addresses a possible failure path in the file list datatype to prevent failures elsewhere in Arches (I couldn't verify anything was breaking, though).