### PR TITLE
Ensure consistency of response data #40

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -11,6 +11,7 @@ omit =
     */hosts.py
     */celery.py
     */__init__.py
+    arches_querysets/management/commands/add_test_data.py
 
 data_file = coverage/python/.coverage
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ AliasedData(string={'en': {'direction': 'ltr', 'value': 'forty-two'}},
 
 In [3]: result.aliased_data.datatypes_1.aliased_data.string = 'new value'
 
-In [4]: result.save(index=False)  # indexing avoided purely for 7.6/8.0 test data compat
+In [4]: result.save()
 ```
 
 ### How would this help an Arches developer?

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -201,6 +201,7 @@ class TileTree(TileModel):
         db_table = "tiles"
 
     def __init__(self, *args, **kwargs):
+        self._as_representation = kwargs.pop("__as_representation", False)
         self._request = kwargs.pop("__request", None)
         arches_model_kwargs, other_kwargs = pop_arches_model_kwargs(
             kwargs, self._meta.get_fields()
@@ -213,7 +214,6 @@ class TileTree(TileModel):
         self._permitted_nodes = Node.objects.none()
         # Data-collecting nodes that were queried
         self._queried_nodes = Node.objects.none()
-        self._as_representation = False
 
     @property
     def aliased_data(self):

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -251,7 +251,11 @@ class TileTree(TileModel, AliasedDataMixin):
             )
         request = request or self._request
         # Mimic some computations trapped on TileModel.save().
-        if self.sortorder is None or self.is_fully_provisional():
+        if (
+            arches_version >= (8, 0)
+            and self.sortorder is None
+            or self.is_fully_provisional()
+        ):
             self.set_next_sort_order()
         self._save_aliased_data(request=request, index=index, **kwargs)
 

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -242,10 +242,6 @@ class TileTree(TileModel, AliasedDataMixin):
     def parent(self, parent):
         self._parent = parent
 
-    @property
-    def resource_or_none(self):
-        return self.resourceinstance if self.resourceinstance_id else None
-
     def save(self, *, request=None, index=True, **kwargs):
         if arches_version < (8, 0) and self.nodegroup:
             # Cannot supply this too early, as nodegroup might be included
@@ -528,7 +524,7 @@ class TileTree(TileModel, AliasedDataMixin):
                 details=compiled_json.get("details"),
                 # An optional extra hint for the ResourceInstance{list} types
                 # so that prefetched related resources can be used.
-                resource=self.resource_or_none,
+                resource=self.resourceinstance if self.resourceinstance_id else None,
             ),
         }
         if pair["display_value"] in empty_values:
@@ -545,9 +541,8 @@ class TileTree(TileModel, AliasedDataMixin):
             final_val = self.get_display_interchange_pair(node, node_value)
         else:
             if hasattr(datatype_instance, "to_python"):
-                final_val = datatype_instance.to_python(
-                    node_value, resource=self.resource_or_none
-                )
+                resource = self.resourceinstance if self.resourceinstance_id else None
+                final_val = datatype_instance.to_python(node_value, resource=resource)
             else:
                 final_val = node_value
 

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -470,6 +470,7 @@ class ArchesTileSerializer(serializers.ModelSerializer, NodeFetcherMixin):
         if arches_version < (8, 0):
             validated_data["data"] = {}
         validated_data["__request"] = self.context["request"]
+        validated_data["__as_representation"] = True
         with transaction.atomic():
             created = super().create(validated_data)
         return created

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -461,12 +461,6 @@ class ArchesTileSerializer(serializers.ModelSerializer, NodeFetcherMixin):
             user=self.context["request"].user,
         )
         validated_data["nodegroup_id"] = qs._entry_node.nodegroup_id
-        if validated_data.get("sortorder") is None:
-            # Use a dummy instance to avoid save() and signals.
-            dummy_instance = options.model(**validated_data)
-            dummy_instance.sortorder = None
-            dummy_instance.set_next_sort_order()
-            validated_data["sortorder"] = dummy_instance.sortorder
         if arches_version < (8, 0):
             validated_data["data"] = {}
         validated_data["__request"] = self.context["request"]

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,0 +1,58 @@
+from http import HTTPStatus
+
+from django.core.management import call_command
+from django.urls import reverse
+
+from tests.utils import GraphTestCase
+
+
+class RestFrameworkTests(GraphTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        call_command("add_test_users", verbosity=0)
+
+    def test_create_tile_existing_resource(self):
+        create_url = reverse(
+            "api-tiles",
+            kwargs={"graph": "datatype_lookups", "nodegroup_alias": "datatypes_n"},
+        )
+        request_body = {"aliased_data": {"string_n": "create_value"}}
+
+        # Anonymous user lacks editing permissions.
+        with self.assertLogs("django.request", level="WARNING"):
+            forbidden_response = self.client.post(
+                create_url, request_body, content_type="application/json"
+            )
+            self.assertEqual(forbidden_response.status_code, HTTPStatus.FORBIDDEN)
+
+        # Dev user can edit ...
+        self.client.login(username="dev", password="dev")
+        with self.assertLogs("django.request", level="WARNING"):
+            response = self.client.post(
+                create_url, request_body, content_type="application/json"
+            )
+
+        self.assertJSONEqual(
+            response.content,
+            {"resourceinstance": ["This field cannot be null."]},
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST, response.content)
+
+        # ... if a resource is specified.
+        request_body["resourceinstance"] = str(self.resource_42.pk)
+        response = self.client.post(
+            create_url, request_body, content_type="application/json"
+        )
+
+        # The response includes the context.
+        self.assertEqual(
+            response.json()["aliased_data"]["string_n"],
+            {
+                "display_value": "create_value",
+                "interchange_value": {
+                    "en": {"value": "create_value", "direction": "ltr"},
+                },
+            },
+        )
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -41,7 +41,7 @@ class SaveTileTests(GraphTestCase):
         self.resource_42.refresh_from_db()
         self.resource_42.fill_blanks()
         # Saving a blank tile should populate default values if defaults are defined.
-        self.resource_42.save(index=False)
+        self.resource_42.save()
         self.assert_default_values_present(self.resource_42)
 
         # fill_blanks gives an unsaved empty tile, but we also need to test that inserting
@@ -54,7 +54,7 @@ class SaveTileTests(GraphTestCase):
         for node in self.resource_42.aliased_data.datatypes_1.data:
             self.resource_42.aliased_data.datatypes_1.data[node] = None
         # Save should stock defaults
-        self.resource_42.aliased_data.datatypes_1.save(index=False)
+        self.resource_42.aliased_data.datatypes_1.save()
         self.assert_default_values_present(self.resource_42)
 
     def test_fill_blanks(self):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -32,7 +32,7 @@ class SerializationTests(GraphTestCase):
         )
 
         # Clone nodes.
-        for node in cls.nodes:
+        for node in cls.data_nodes:
             node.pk = uuid.uuid4()
             node.name = node.name + "-child"
             node.alias = node.alias + "_child"
@@ -41,7 +41,7 @@ class SerializationTests(GraphTestCase):
                 if node.nodegroup == cls.nodegroup_1
                 else cls.nodegroup_n_child
             )
-        Node.objects.bulk_create(cls.nodes)
+        Node.objects.bulk_create(cls.data_nodes)
 
         # Create data for the child non-localized-string node only.
         # TileModel.save() will initialize the other nodes to None.


### PR DESCRIPTION
Ensure consistent return shape (e.g. no naked data, always wrapped in `{"display_value": ...` etc
Closes #40

See notes below