### PR TITLE
Fix alias collisions #58

### DIFF
--- a/tests/test_internals.py
+++ b/tests/test_internals.py
@@ -1,0 +1,12 @@
+from arches_querysets.models import TileTree
+from tests.utils import GraphTestCase
+
+
+class InternalsTests(GraphTestCase):
+    def test_node_alias_collision_with_model_field(self):
+        self.file_list_node_1.alias = "file"
+        self.file_list_node_1.save()
+        # Previously, this clashed with the related query name "file"
+        qs = TileTree.get_tiles(graph_slug="datatype_lookups", nodegroup_alias="file")
+        # TODO: determine the reserved namespace to use here.
+        self.assertFalse(qs.filter(_arches_querysets_file__isnull=False).exists())

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,5 +1,3 @@
-from types import SimpleNamespace
-
 from django.core.exceptions import ValidationError
 
 from arches_querysets.models import ResourceTileTree, TileTree

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -107,24 +107,12 @@ class GraphTestCase(TestCase):
             *cls.data_nodes,
         ]
 
-        cls.ri_node_1, cls.ri_node_n = [
-            node for node in cls.nodes if node.datatype == "resource-instance"
-        ]
-        cls.ri_list_node_1, cls.ri_list_node_n = [
-            node for node in cls.nodes if node.datatype == "resource-instance-list"
-        ]
-        cls.date_node_1, cls.date_node_n = [
-            node for node in cls.nodes if node.datatype == "date"
-        ]
-        cls.string_node_1, cls.string_node_n = [
-            node for node in cls.nodes if node.datatype == "string"
-        ]
-        cls.node_value_node_1, cls.node_value_node_n = [
-            node for node in cls.nodes if node.datatype == "node-value"
-        ]
-        cls.url_node_1, cls.url_node_n = [
-            node for node in cls.nodes if node.datatype == "url"
-        ]
+        # Set each node as an attribute, e.g. self.string_node_n
+        for node in cls.data_nodes:
+            attname = node.datatype.replace("-", "_")
+            attname += "_node_1" if node.nodegroup.cardinality == "1" else "_node_n"
+            setattr(cls, attname, node)
+
         cls.node_value_node_1.config["nodeid"] = str(cls.date_node_1.pk)
         cls.node_value_node_1.save()
         cls.node_value_node_n.config["nodeid"] = str(cls.date_node_n.pk)
@@ -376,7 +364,7 @@ class GraphTestCase(TestCase):
                     from_graph_attr: cls.graph,
                     to_graph_attr: cls.graph,
                     tile_attr: cls.cardinality_1_tile,
-                    node_attr: cls.ri_node_1,
+                    node_attr: cls.resource_instance_node_1,
                 }
             ),
             ResourceXResource(
@@ -386,7 +374,7 @@ class GraphTestCase(TestCase):
                     from_graph_attr: cls.graph,
                     to_graph_attr: cls.graph,
                     tile_attr: cls.cardinality_n_tile,
-                    node_attr: cls.ri_node_n,
+                    node_attr: cls.resource_instance_node_n,
                 }
             ),
             ResourceXResource(
@@ -396,7 +384,7 @@ class GraphTestCase(TestCase):
                     from_graph_attr: cls.graph,
                     to_graph_attr: cls.graph,
                     tile_attr: cls.cardinality_1_tile,
-                    node_attr: cls.ri_list_node_1,
+                    node_attr: cls.resource_instance_list_node_1,
                 }
             ),
             ResourceXResource(
@@ -406,7 +394,7 @@ class GraphTestCase(TestCase):
                     from_graph_attr: cls.graph,
                     to_graph_attr: cls.graph,
                     tile_attr: cls.cardinality_n_tile,
-                    node_attr: cls.ri_list_node_n,
+                    node_attr: cls.resource_instance_list_node_n,
                 }
             ),
         ]


### PR DESCRIPTION
Got nailed on this long-standing `TODO` 😉 

Node aliases are given to Django as queryset aliases so you can do `.filter(my_alias...`, and Django is smart enough to prune the unused aliases you don't use. You just can't give it one that clashes with a model field like `file`.

We can finalize this behavior when we work on advanced search (e.g. if `__file` instead of `file` is good enough. But no active projects are making use of filtering, so this shouldn't be a disruptive change).

Closes #58