### PR TITLE
Raise error if resource is out-of-date

### DIFF
--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -120,7 +120,9 @@ class ResourceTileTree(ResourceInstance, AliasedDataMixin):
         self._aliased_data = value
 
     def save(self, *, request=None, index=True, force_admin=False, **kwargs):
-        self._save_aliased_data(request=request, index=index, force_admin=force_admin, **kwargs)
+        self._save_aliased_data(
+            request=request, index=index, force_admin=force_admin, **kwargs
+        )
 
     @classmethod
     def get_tiles(
@@ -261,7 +263,9 @@ class TileTree(TileModel, AliasedDataMixin):
             or self.is_fully_provisional()
         ):
             self.set_next_sort_order()
-        self._save_aliased_data(request=request, index=index, force_admin=force_admin, **kwargs)
+        self._save_aliased_data(
+            request=request, index=index, force_admin=force_admin, **kwargs
+        )
 
     @classmethod
     def get_tiles(
@@ -556,7 +560,9 @@ class TileTree(TileModel, AliasedDataMixin):
 
         setattr(self.aliased_data, node.alias, final_val)
 
-    def _save_aliased_data(self, *, request=None, index=True, force_admin=False, **kwargs):
+    def _save_aliased_data(
+        self, *, request=None, index=True, force_admin=False, **kwargs
+    ):
         request = ensure_request(request, force_admin)
         operation = TileTreeOperation(entry=self, request=request, save_kwargs=kwargs)
         operation.validate_and_save_tiles()

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -120,6 +120,11 @@ class ResourceTileTree(ResourceInstance, AliasedDataMixin):
         self._aliased_data = value
 
     def save(self, *, request=None, index=True, force_admin=False, **kwargs):
+        if self.graph_publication_id and (
+            self.graph_publication_id != self.graph.publication_id
+        ):
+            raise ValidationError(_("Graph Has Different Publication"))
+
         self._save_aliased_data(
             request=request, index=index, force_admin=force_admin, **kwargs
         )
@@ -249,6 +254,16 @@ class TileTree(TileModel, AliasedDataMixin):
         self._parent = parent
 
     def save(self, *, request=None, index=True, force_admin=False, **kwargs):
+        if (
+            self.resourceinstance_id
+            and self.resourceinstance.graph_publication_id
+            and (
+                self.resourceinstance.graph_publication_id
+                != self.resourceinstance.graph.publication_id
+            )
+        ):
+            raise ValidationError(_("Graph Has Different Publication"))
+
         if arches_version < (8, 0) and self.nodegroup:
             # Cannot supply this too early, as nodegroup might be included
             # with the request and already instantiated to a fresh object.

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -472,6 +472,9 @@ class ArchesResourceSerializer(serializers.ModelSerializer, NodeFetcherMixin):
     # aliased_data is a virtual field not inferred by serializers.ModelSerializer.
     aliased_data = ResourceAliasedDataSerializer(required=False, allow_null=False)
 
+    # Custom read-only fields.
+    graph_has_different_publication = serializers.SerializerMethodField()
+
     class Meta:
         model = ResourceTileTree
         # If None, supply by a route providing a <slug:graph> component
@@ -546,6 +549,13 @@ class ArchesResourceSerializer(serializers.ModelSerializer, NodeFetcherMixin):
             )
             updated = self.update(instance_from_factory, validated_data)
         return updated
+
+    def get_graph_has_different_publication(self, obj):
+        if arches_version < (8, 0):
+            return False
+        return obj.graph_publication_id and (
+            obj.graph_publication_id != obj.graph.publication_id
+        )
 
 
 # Workaround for I18n_string fields

--- a/arches_querysets/utils/tests.py
+++ b/arches_querysets/utils/tests.py
@@ -42,6 +42,7 @@ class GraphTestCase(TestCase):
         if arches_version < (8, 0):
             graph_proxy.refresh_from_database()
         graph_proxy.publish(user=None)
+        cls.graph.publication = graph_proxy.publication
 
     @classmethod
     def create_graph(cls):
@@ -215,11 +216,13 @@ class GraphTestCase(TestCase):
             graph=cls.graph,
             descriptors={"en": {"name": "Resource referencing 42"}},
             name="Resource referencing 42",
+            graph_publication_id=cls.graph.publication_id,
         )
         cls.resource_none = ResourceInstance.objects.create(
             graph=cls.graph,
             descriptors={"en": {"name": "Resource referencing None"}},
             name="Resource referencing None",
+            graph_publication_id=cls.graph.publication_id,
         )
 
     @classmethod

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -12,10 +12,14 @@ class SaveTileTests(GraphTestCase):
             "datatype_lookups", as_representation=True
         )
         cls.resource_42 = resources.get(pk=cls.resource_42.pk)
+        cls.resource_42.graph_publication_id = cls.graph.publication_id
+        cls.resource_42.save()
         cls.datatype_1 = cls.resource_42.aliased_data.datatypes_1
         cls.datatype_n = cls.resource_42.aliased_data.datatypes_n
 
         cls.resource_none = resources.get(pk=cls.resource_none.pk)
+        cls.resource_none.graph_publication_id = cls.graph.publication_id
+        cls.resource_none.save()
         cls.datatype_1_none = cls.resource_none.aliased_data.datatypes_1
         cls.datatype_n_none = cls.resource_none.aliased_data.datatypes_n
 


### PR DESCRIPTION
Closes archesproject/arches-lingo#349

unless we wish to keep it open so that we can consume this `graph_has_different_publication: true` in the UI to disable a form or hide a link.

#### Demo
<img width="468" height="254" alt="Screenshot 2025-07-15 at 12 44 05 PM" src="https://github.com/user-attachments/assets/a3e5f3bd-887e-45d2-ab6a-38fa29e18d04" />

