### PR TITLE
Prevent error when transform_value_for_tile is passed a list of dictionaries

### DIFF
--- a/arches_querysets/datatypes/file.py
+++ b/arches_querysets/datatypes/file.py
@@ -2,6 +2,7 @@ from django.utils.translation import get_language
 
 from arches.app.datatypes import datatypes
 from arches.app.models import models
+from arches import VERSION as arches_version
 
 
 class FileListDataType(datatypes.FileListDataType):
@@ -14,12 +15,13 @@ class FileListDataType(datatypes.FileListDataType):
             languages = models.Language.objects.all()
 
         language = get_language()
-        stringified_list = ",".join([file_info.get("name") for file_info in value])
-        final_value = super().transform_value_for_tile(
-            stringified_list, languages=languages, **kwargs
-        )
 
-        for file_info in final_value:
+        if not isinstance(value, dict) and arches_version < (8, 1):
+            value = super().transform_value_for_tile(
+                value, languages=languages, **kwargs
+            )
+
+        for file_info in value:
             for key, val in file_info.items():
                 if key not in self.localized_metadata_keys:
                     continue
@@ -33,4 +35,4 @@ class FileListDataType(datatypes.FileListDataType):
                             "direction": lang.default_direction,
                         }
 
-        return final_value
+        return value


### PR DESCRIPTION
Prevents error when transform_value_for_tile is passed a string of file names rather than a list of dictionaries.