### PR TITLE
Add blank views #72

### DIFF
--- a/.github/actions/build-and-test-branch/action.yml
+++ b/.github/actions/build-and-test-branch/action.yml
@@ -97,6 +97,7 @@ runs:
       shell: bash
 
     - name: Generate Python report coverage
+      if: inputs.arches-version != '7.6'
       run: |
         coverage report
         coverage json
@@ -111,6 +112,7 @@ runs:
     #     overwrite: true
 
     - name: Upload Python coverage report as artifact
+      if: inputs.arches-version != '7.6'
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.branch-type }}-branch-python-coverage-report

--- a/arches_querysets/rest_framework/generic_views.py
+++ b/arches_querysets/rest_framework/generic_views.py
@@ -1,4 +1,8 @@
-from rest_framework.generics import ListCreateAPIView, RetrieveUpdateDestroyAPIView
+from rest_framework.generics import (
+    ListCreateAPIView,
+    RetrieveAPIView,
+    RetrieveUpdateDestroyAPIView,
+)
 from rest_framework.parsers import JSONParser
 
 from arches_querysets.rest_framework.multipart_json_parser import MultiPartJSONParser
@@ -6,6 +10,8 @@ from arches_querysets.rest_framework.pagination import ArchesLimitOffsetPaginati
 from arches_querysets.rest_framework.permissions import ReadOnly, ResourceEditor
 from arches_querysets.rest_framework.serializers import (
     ArchesResourceSerializer,
+    ArchesResourceTopNodegroupsSerializer,
+    ArchesSingleNodegroupSerializer,
     ArchesTileSerializer,
 )
 from arches_querysets.rest_framework.view_mixins import ArchesModelAPIMixin
@@ -35,3 +41,32 @@ class ArchesTileDetailView(ArchesModelAPIMixin, RetrieveUpdateDestroyAPIView):
     permission_classes = [ResourceEditor | ReadOnly]
     serializer_class = ArchesTileSerializer
     parser_classes = [JSONParser, MultiPartJSONParser]
+
+
+### Views for returning blank resource & tile templates
+
+
+class ArchesResourceBlankView(ArchesModelAPIMixin, RetrieveAPIView):
+    permission_classes = [ReadOnly]
+    serializer_class = ArchesResourceSerializer
+
+    def get_serializer_class(self):
+        if self.request.GET.get("exclude_children", "").lower() == "true":
+            return ArchesResourceTopNodegroupsSerializer
+        return self.serializer_class
+
+    def get_object(self, *args, **kwargs):
+        return None
+
+
+class ArchesTileBlankView(ArchesModelAPIMixin, RetrieveAPIView):
+    permission_classes = [ReadOnly]
+    serializer_class = ArchesTileSerializer
+
+    def get_serializer_class(self):
+        if self.request.GET.get("exclude_children", "").lower() == "true":
+            return ArchesSingleNodegroupSerializer
+        return self.serializer_class
+
+    def get_object(self, *args, **kwargs):
+        return None

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -473,9 +473,7 @@ class SingleNodegroupAliasedDataSerializer(TileAliasedDataSerializer):
 class ArchesTileSerializer(serializers.ModelSerializer, NodeFetcherMixin):
     # These fields are declared here in full instead of massaged via
     # "extra_kwargs" in class Meta to support subclassing by TileAliasedDataSerializer.
-    tileid = serializers.UUIDField(
-        validators=[], required=False, initial=uuid.uuid4, allow_null=True
-    )
+    tileid = serializers.UUIDField(validators=[], required=False, allow_null=True)
     resourceinstance = serializers.PrimaryKeyRelatedField(
         queryset=ResourceTileTree.objects.all(),
         required=False,
@@ -604,7 +602,7 @@ class ArchesResourceSerializer(serializers.ModelSerializer, NodeFetcherMixin):
             "resource_instance_lifecycle_state",
         )
         extra_kwargs = {
-            "resourceinstanceid": {"initial": uuid.uuid4, "allow_null": True},
+            "resourceinstanceid": {"initial": None, "allow_null": True},
             "graph": {"allow_null": True},
         }
 

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -504,7 +504,6 @@ class ArchesTileSerializer(serializers.ModelSerializer, NodeFetcherMixin):
     def __init__(self, instance=None, data=empty, *, context=None, **kwargs):
         self._graph_slug = kwargs.pop("graph_slug", None)
         self._permitted_nodes = kwargs.pop("permitted_nodes", [])
-        self.parent = None
         if not context:
             context = self.ensure_context(
                 graph_slug=self._graph_slug,

--- a/arches_querysets/urls.py
+++ b/arches_querysets/urls.py
@@ -5,8 +5,10 @@ from django.urls import include, path
 
 from arches_querysets.apps import ArchesQuerySetsConfig
 from arches_querysets.rest_framework.generic_views import (
+    ArchesResourceBlankView,
     ArchesResourceDetailView,
     ArchesResourceListCreateView,
+    ArchesTileBlankView,
     ArchesTileDetailView,
     ArchesTileListCreateView,
 )
@@ -24,6 +26,11 @@ arches_rest_framework_urls = [
         name="api-resource",
     ),
     path(
+        "api/resource/<slug:graph>/blank",
+        ArchesResourceBlankView.as_view(),
+        name="api-resource-blank",
+    ),
+    path(
         "api/tile/<slug:graph>/<slug:nodegroup_alias>",
         ArchesTileListCreateView.as_view(),
         name="api-tiles",
@@ -32,6 +39,11 @@ arches_rest_framework_urls = [
         "api/tile/<slug:graph>/<slug:nodegroup_alias>/<uuid:pk>",
         ArchesTileDetailView.as_view(),
         name="api-tile",
+    ),
+    path(
+        "api/tile/<slug:graph>/<slug:nodegroup_alias>/blank",
+        ArchesTileBlankView.as_view(),
+        name="api-tile-blank",
     ),
 ]
 

--- a/arches_querysets/utils/tests.py
+++ b/arches_querysets/utils/tests.py
@@ -48,6 +48,13 @@ class GraphTestCase(TestCase):
         graph_proxy = Graph.objects.get(pk=cls.graph.pk)
         if arches_version < (8, 0):
             graph_proxy.refresh_from_database()
+            if cls.test_child_nodegroups:
+                # Repair parent nodegroup link broken by get_nodegroups()!
+                for node in graph_proxy.nodes.values():
+                    if node.nodegroup == cls.nodegroup_1_child:
+                        if node.nodegroup.parentnodegroup != cls.nodegroup_1:
+                            node.nodegroup.parentnodegroup = cls.nodegroup_1
+                            node.nodegroup.save()
         graph_proxy.publish(user=None)
         cls.graph.publication = graph_proxy.publication
 

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,4 +1,5 @@
 import unittest
+import uuid
 from http import HTTPStatus
 
 from django.core.management import call_command
@@ -7,6 +8,10 @@ from arches import VERSION as arches_version
 from arches.app.models.graph import Graph
 from arches.app.models.models import EditLog
 
+from arches_querysets.rest_framework.serializers import (
+    ArchesResourceSerializer,
+    ArchesTileSerializer,
+)
 from arches_querysets.utils.tests import GraphTestCase
 
 
@@ -110,3 +115,22 @@ class RestFrameworkTests(GraphTestCase):
             "Graph Has Different Publication",
             status_code=HTTPStatus.BAD_REQUEST,
         )
+
+    def test_instantiate_empty_resource_serializer(self):
+        serializer = ArchesResourceSerializer(graph_slug="datatype_lookups")
+        self.assertIsInstance(serializer.data["resourceinstanceid"], uuid.UUID)
+        # Default values are stocked.
+        self.assertEqual(
+            serializer.data["aliased_data"]["datatypes_1"]["aliased_data"]["number"][
+                "node_value"
+            ],
+            7,
+        )
+
+    def test_instantiate_empty_tile_serializer(self):
+        serializer = ArchesTileSerializer(
+            graph_slug="datatype_lookups", nodegroup_alias="datatypes_1"
+        )
+        self.assertIsInstance(serializer.data["tileid"], uuid.UUID)
+        # Default values are stocked.
+        self.assertEqual(serializer.data["aliased_data"]["number"]["node_value"], 7)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -120,7 +120,7 @@ class RestFrameworkTests(GraphTestCase):
 
     def test_instantiate_empty_resource_serializer(self):
         serializer = ArchesResourceSerializer(graph_slug="datatype_lookups")
-        self.assertIsInstance(serializer.data["resourceinstanceid"], uuid.UUID)
+        self.assertIsNone(serializer.data["resourceinstanceid"])
         # Default values are stocked.
         self.assertEqual(
             serializer.data["aliased_data"]["datatypes_1"]["aliased_data"]["number"][
@@ -133,7 +133,7 @@ class RestFrameworkTests(GraphTestCase):
         serializer = ArchesTileSerializer(
             graph_slug="datatype_lookups", nodegroup_alias="datatypes_1"
         )
-        self.assertIsInstance(serializer.data["tileid"], uuid.UUID)
+        self.assertIsNone(serializer.data["tileid"])
         # Default values are stocked.
         self.assertEqual(serializer.data["aliased_data"]["number"]["node_value"], 7)
 

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -11,6 +11,8 @@ from arches_querysets.utils.tests import GraphTestCase
 
 
 class RestFrameworkTests(GraphTestCase):
+    test_child_nodegroups = True
+
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,5 +1,4 @@
 import unittest
-import uuid
 from http import HTTPStatus
 
 from django.core.management import call_command

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -10,6 +10,8 @@ from arches.app.models.models import EditLog
 
 from arches_querysets.rest_framework.serializers import (
     ArchesResourceSerializer,
+    ArchesResourceTopNodegroupsSerializer,
+    ArchesSingleNodegroupSerializer,
     ArchesTileSerializer,
 )
 from arches_querysets.utils.tests import GraphTestCase
@@ -134,3 +136,63 @@ class RestFrameworkTests(GraphTestCase):
         self.assertIsInstance(serializer.data["tileid"], uuid.UUID)
         # Default values are stocked.
         self.assertEqual(serializer.data["aliased_data"]["number"]["node_value"], 7)
+
+    def test_exclude_children_option(self):
+        serializer = ArchesResourceSerializer(graph_slug="datatype_lookups")
+        self.assertIn(
+            "datatypes_1_child",
+            serializer.data["aliased_data"]["datatypes_1"]["aliased_data"],
+        )
+        serializer = ArchesResourceTopNodegroupsSerializer(
+            graph_slug="datatype_lookups"
+        )
+        self.assertNotIn(
+            "datatypes_1_child",
+            serializer.data["aliased_data"]["datatypes_1"]["aliased_data"],
+        )
+        serializer = ArchesTileSerializer(
+            graph_slug="datatype_lookups", nodegroup_alias="datatypes_1"
+        )
+        self.assertIn("datatypes_1_child", serializer.data["aliased_data"])
+        serializer = ArchesSingleNodegroupSerializer(
+            graph_slug="datatype_lookups", nodegroup_alias="datatypes_1"
+        )
+        self.assertNotIn("datatypes_1_child", serializer.data["aliased_data"])
+
+    def test_blank_views_exclude_children_option(self):
+        response = self.client.get(
+            reverse(
+                "api-resource-blank",
+                kwargs={"graph": "datatype_lookups"},
+            )
+        )
+        self.assertContains(response, "datatypes_1_child")
+
+        response = self.client.get(
+            reverse(
+                "api-resource-blank",
+                kwargs={"graph": "datatype_lookups"},
+            ),
+            QUERY_STRING="exclude_children=true",
+        )
+        self.assertNotContains(response, "datatypes_1_child")
+
+        response = self.client.get(
+            reverse(
+                "api-tile-blank",
+                kwargs={"graph": "datatype_lookups", "nodegroup_alias": "datatypes_1"},
+            )
+        )
+        self.assertContains(response, "datatypes_1_child")
+
+        response = self.client.get(
+            reverse(
+                "api-tile-blank",
+                kwargs={
+                    "graph": "datatype_lookups",
+                    "nodegroup_alias": "datatypes_1",
+                },
+            ),
+            QUERY_STRING="exclude_children=true",
+        )
+        self.assertNotContains(response, "datatypes_1_child")

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -25,7 +25,7 @@ class SaveTileTests(GraphTestCase):
 
     def assert_default_values_present(self, resource):
         for node_id_str, value in resource.aliased_data.datatypes_1.data.items():
-            node = [node for node in self.nodes if str(node.pk) == node_id_str][0]
+            node = [node for node in self.data_nodes if str(node.pk) == node_id_str][0]
             with self.subTest(alias=node.alias):
                 default_value = self.default_vals_by_nodeid[node_id_str]
                 expected = TileTree.get_cleaned_default_value(node, default_value)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,68 +1,9 @@
-import uuid
-
-from arches.app.models.models import Node, TileModel
 from arches.app.utils.betterJSONSerializer import JSONDeserializer, JSONSerializer
-from arches_querysets.models import ResourceTileTree
 from arches_querysets.utils.tests import GraphTestCase
 
 
 class SerializationTests(GraphTestCase):
-    @classmethod
-    def setUpTestData(cls):
-        super().setUpTestData()
-
-        # Create child nodegroups and tiles.
-        cls.nodegroup_1_child, _ = cls.create_nodegroup(
-            "datatypes_1_child", "1", parent_nodegroup=cls.nodegroup_1
-        )
-        cls.nodegroup_n_child, _ = cls.create_nodegroup(
-            "datatypes_n_child", "n", parent_nodegroup=cls.nodegroup_n
-        )
-        cls.cardinality_1_child_tile = TileModel.objects.create(
-            nodegroup=cls.nodegroup_1_child,
-            resourceinstance=cls.resource_42,
-            data={},
-            parenttile=cls.cardinality_1_tile,
-        )
-        cls.cardinality_n_child_tile = TileModel.objects.create(
-            nodegroup=cls.nodegroup_n_child,
-            resourceinstance=cls.resource_42,
-            data={},
-            parenttile=cls.cardinality_n_tile,
-        )
-
-        # Clone nodes.
-        for node in cls.data_nodes:
-            node.pk = uuid.uuid4()
-            node.name = node.name + "-child"
-            node.alias = node.alias + "_child"
-            node.nodegroup = (
-                cls.nodegroup_1_child
-                if node.nodegroup == cls.nodegroup_1
-                else cls.nodegroup_n_child
-            )
-        Node.objects.bulk_create(cls.data_nodes)
-
-        # Create data for the child non-localized-string node only.
-        # TileModel.save() will initialize the other nodes to None.
-        cls.non_localized_string_child_node = Node.objects.get(
-            alias="non_localized_string_child"
-        )
-        cls.non_localized_string_child_node_n = Node.objects.get(
-            alias="non_localized_string_n_child"
-        )
-        cls.cardinality_1_child_tile.data = {
-            str(cls.non_localized_string_child_node): "child-1-value",
-        }
-        cls.cardinality_1_child_tile.save()
-        cls.cardinality_n_child_tile.data = {
-            str(cls.non_localized_string_child_node_n): "child-n-value",
-        }
-        cls.cardinality_n_child_tile.save()
-
-        cls.resource = ResourceTileTree.get_tiles(
-            "datatype_lookups", as_representation=True
-        ).get(pk=cls.resource_42.pk)
+    test_child_nodegroups = True
 
     def test_serialization_via_better_json_serializer(self):
         dict_string = JSONSerializer().serialize(self.resource)


### PR DESCRIPTION
Add views that return a empty serializer stocked with initial values.

While here, harden the features that are supposed to enable doing this in a script/shell (see test for usage example)

Closes #72

#### Demo
(using lingo, which doesn't have many default values?):
http://127.0.0.1:8000/api/tile/scheme/rights/blank

GET /api/tile/scheme/rights/blank
HTTP 200 OK
```json
{
    "tileid": "44d5c917-a139-4ba9-aa3e-7749dd09b4c9",
    "resourceinstance": null,
    "nodegroup": null,
    "parenttile": null,
    "aliased_data": {
        "right_holder": {
            "node_value": null,
            "display_value": "(Empty)",
            "details": []
        },
        "right_type": {
            "node_value": null,
            "display_value": "(Empty)",
            "details": []
        },
        "right_statement": {
            "tileid": "589af217-818e-4899-ab3a-aad7ba017ad1",
            "resourceinstance": null,
            "nodegroup": null,
            "parenttile": null,
            "aliased_data": {
                "right_statement_language": {
                    "node_value": null,
                    "display_value": "(Empty)",
                    "details": []
                },
                "right_statement_type_metatype": {
                    "node_value": null,
                    "display_value": "(Empty)",
                    "details": []
                },
                "right_statement_label": {
                    "node_value": null,
                    "display_value": "(Empty)",
                    "details": []
                },
                "right_statement_type": {
                    "node_value": null,
                    "display_value": "(Empty)",
                    "details": []
                },
                "right_statement_content": {
                    "node_value": null,
                    "display_value": "(Empty)",
                    "details": []
                }
            },
            "sortorder": null,
            "provisionaledits": null
        }
    },
    "sortorder": null,
    "provisionaledits": null
}
```