### PR TITLE
Post 1.0.0b2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.10"
 dependencies = [
     "arches>=7.6.12,<8.1.0,!=8.0.0",
 ]
-version = "1.0.0b2"
+version = "1.0.0b3-dev"
 
 [project.optional-dependencies]
 drf = ["djangorestframework~=3.16"]


### PR DESCRIPTION
Cherry-pick the commit with the version bump, then increment it again to a dev version so that the dev version is always "greater" than what was released.