### PR TITLE
fixes incorrect method call

### DIFF
--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -387,7 +387,7 @@ class TileTree(TileModel, AliasedDataMixin):
         if not getattr(self, "_nodegroup_alias", None):
             # But perform a last-minute check just in case. This will
             # also run if the node alias is null.
-            if grouping_node := Node.objects.get(pk=self.nodegroup_id):
+            if grouping_node := Node.objects.filter(pk=self.nodegroup_id).first():
                 self._nodegroup_alias = grouping_node.alias
         return self._nodegroup_alias
 

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -387,7 +387,7 @@ class TileTree(TileModel, AliasedDataMixin):
         if not getattr(self, "_nodegroup_alias", None):
             # But perform a last-minute check just in case. This will
             # also run if the node alias is null.
-            if grouping_node := Node.objects.first(pk=self.nodegroup_id):
+            if grouping_node := Node.objects.get(pk=self.nodegroup_id):
                 self._nodegroup_alias = grouping_node.alias
         return self._nodegroup_alias
 


### PR DESCRIPTION
found this when I was debugging an issue where I didn't have a node alias

was seeing this error
```
QuerySet.first() got an unexpected keyword argument 'pk'
```