### PR TITLE
Let fill_blanks() work even when top cards have tiles

### DIFF
--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -526,7 +526,7 @@ class TileTree(TileModel, AliasedDataMixin):
     def find_nodegroup_from_alias_or_pk(alias=None, *, permitted_nodes, pk=None):
         """Some of this complexity can be removed when dropping 7.6."""
         for permitted_node in permitted_nodes:
-            if permitted_node.alias == alias or permitted_node.pk == pk:
+            if (alias and permitted_node.alias == alias) or permitted_node.pk == pk:
                 permitted_node.nodegroup._nodegroup_alias = permitted_node.alias
                 return permitted_node.nodegroup
         raise RuntimeError

--- a/arches_querysets/utils/models.py
+++ b/arches_querysets/utils/models.py
@@ -267,6 +267,8 @@ def get_recursive_prefetches(lookup_str, *, recursive_part="children", depth):
 
 
 def append_tiles_recursively(resource_or_tile):
+    from arches_querysets.models import TileTree
+
     if not vars(resource_or_tile.aliased_data):
         raise RuntimeError("aliased_data is empty")
 
@@ -278,9 +280,10 @@ def append_tiles_recursively(resource_or_tile):
                 continue
 
             tiles = getattr(resource_or_tile.aliased_data, alias)
-            if not isinstance(tiles, list):
-                tiles = [tiles]
-            for tile in tiles:
+        if not isinstance(tiles, list):
+            tiles = [tiles]
+        for tile in tiles:
+            if isinstance(tile, TileTree):
                 tile.fill_blanks()
 
 

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -5,6 +5,8 @@ from arches_querysets.utils.tests import GraphTestCase
 
 
 class SaveTileTests(GraphTestCase):
+    test_child_nodegroups = True
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -64,6 +66,20 @@ class SaveTileTests(GraphTestCase):
         self.resource_none.fill_blanks()
         self.assertIsInstance(self.resource_none.aliased_data.datatypes_1, TileTree)
         self.assertIsInstance(self.resource_none.aliased_data.datatypes_n[0], TileTree)
+        self.assertIsInstance(
+            self.resource_none.aliased_data.datatypes_1.aliased_data.datatypes_1_child,
+            TileTree,
+        )
+
+        # Remove the child, fill_blanks() again.
+        self.resource_none.aliased_data.datatypes_1.aliased_data.datatypes_1_child = (
+            None
+        )
+        self.resource_none.fill_blanks()
+        self.assertIsInstance(
+            self.resource_none.aliased_data.datatypes_1.aliased_data.datatypes_1_child,
+            TileTree,
+        )
 
         msg = "Attempted to append to a populated cardinality-1 nodegroup"
         with self.assertRaisesMessage(RuntimeError, msg):


### PR DESCRIPTION
`fill_blanks()` was not filling blanks on child nodegroups if there were tiles for top cards.