### PR TITLE
Expose only queryset urls through urls.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,7 @@ INSTALLED_APPS = [
 ```
 In urls.py:
 ```
-from arches_querysets.urls import arches_rest_framework_urls
-urlpatterns = [
-    ...
-    *arches_rest_framework_urls,
-]
+urlpatterns.append(path("", include("arches_querysets.urls")))
 ```
 
 For developer install instructions, see the [Developer Setup](#developer-setup-for-contributing-to-the-arches-querysets-project) section below.

--- a/arches_querysets/arches_querysets_urls.py
+++ b/arches_querysets/arches_querysets_urls.py
@@ -1,0 +1,30 @@
+from django.conf import settings
+from django.conf.urls.static import static
+from django.conf.urls.i18n import i18n_patterns
+from django.urls import include, path
+
+from arches_querysets.apps import ArchesQuerySetsConfig
+
+app_name = ArchesQuerySetsConfig.name
+urlpatterns = [
+    path("", include("arches_querysets.urls")),
+]
+
+# handler400 = "arches.app.views.main.custom_400"
+# handler403 = "arches.app.views.main.custom_403"
+# handler404 = "arches.app.views.main.custom_404"
+# handler500 = "arches.app.views.main.custom_500"
+
+# Ensure Arches core urls are superseded by project-level urls
+urlpatterns.append(path("", include("arches.urls")))
+
+# Adds URL pattern to serve media files during development
+urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+# Only handle i18n routing in active project. This will still handle the routes provided by Arches core and Arches applications,
+# but handling i18n routes in multiple places causes application errors.
+if settings.ROOT_URLCONF == __name__:
+    if settings.SHOW_LANGUAGE_SWITCH is True:
+        urlpatterns = i18n_patterns(*urlpatterns)
+
+    urlpatterns.append(path("i18n/", include("django.conf.urls.i18n")))

--- a/arches_querysets/hosts.py
+++ b/arches_querysets/hosts.py
@@ -5,7 +5,7 @@ host_patterns = patterns(
     "",
     host(
         re.sub(r"_", r"-", r"arches_querysets"),
-        "arches_querysets.urls",
+        "arches_querysets.arches_querysets_urls",
         name="arches_querysets",
     ),
 )

--- a/arches_querysets/settings.py
+++ b/arches_querysets/settings.py
@@ -58,7 +58,7 @@ SECRET_KEY = "django-insecure-7xnft806s-44r+zchr-*f4cpss&@e6-5r_o0gn+apw6zb*#$p7
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ROOT_URLCONF = "arches_querysets.urls"
+ROOT_URLCONF = "arches_querysets.arches_querysets_urls"
 ROOT_HOSTCONF = "arches_querysets.hosts"
 
 DEFAULT_HOST = "arches_querysets"

--- a/arches_querysets/urls.py
+++ b/arches_querysets/urls.py
@@ -1,7 +1,4 @@
-from django.conf import settings
-from django.conf.urls.static import static
-from django.conf.urls.i18n import i18n_patterns
-from django.urls import include, path
+from django.urls import path
 
 from arches_querysets.apps import ArchesQuerySetsConfig
 from arches_querysets.rest_framework.generic_views import (
@@ -14,7 +11,7 @@ from arches_querysets.rest_framework.generic_views import (
 )
 
 app_name = ArchesQuerySetsConfig.name
-arches_rest_framework_urls = [
+urlpatterns = [
     path(
         "api/resource/<slug:graph>",
         ArchesResourceListCreateView.as_view(),
@@ -46,26 +43,3 @@ arches_rest_framework_urls = [
         name="api-tile-blank",
     ),
 ]
-
-urlpatterns = [
-    *arches_rest_framework_urls,
-]
-
-# handler400 = "arches.app.views.main.custom_400"
-# handler403 = "arches.app.views.main.custom_403"
-# handler404 = "arches.app.views.main.custom_404"
-# handler500 = "arches.app.views.main.custom_500"
-
-# Ensure Arches core urls are superseded by project-level urls
-urlpatterns.append(path("", include("arches.urls")))
-
-# Adds URL pattern to serve media files during development
-urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-
-# Only handle i18n routing in active project. This will still handle the routes provided by Arches core and Arches applications,
-# but handling i18n routes in multiple places causes application errors.
-if settings.ROOT_URLCONF == __name__:
-    if settings.SHOW_LANGUAGE_SWITCH is True:
-        urlpatterns = i18n_patterns(*urlpatterns)
-
-    urlpatterns.append(path("i18n/", include("django.conf.urls.i18n")))

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -29,7 +29,7 @@ class RestFrameworkTests(GraphTestCase):
 
     def test_create_tile_for_new_resource(self):
         create_url = reverse(
-            "api-tiles",
+            "arches_querysets:api-tiles",
             kwargs={"graph": "datatype_lookups", "nodegroup_alias": "datatypes_n"},
         )
         request_body = {"aliased_data": {"string_n": "create_value"}}
@@ -73,7 +73,7 @@ class RestFrameworkTests(GraphTestCase):
 
     def test_create_tile_for_existing_resource(self):
         create_url = reverse(
-            "api-tiles",
+            "arches_querysets:api-tiles",
             kwargs={"graph": "datatype_lookups", "nodegroup_alias": "datatypes_n"},
         )
         request_body = {
@@ -102,7 +102,7 @@ class RestFrameworkTests(GraphTestCase):
         Graph.objects.get(pk=self.graph.pk).publish(user=None)
 
         update_url = reverse(
-            "api-resource",
+            "arches_querysets:api-resource",
             kwargs={"graph": "datatype_lookups", "pk": str(self.resource_42.pk)},
         )
         self.client.login(username="dev", password="dev")
@@ -161,7 +161,7 @@ class RestFrameworkTests(GraphTestCase):
     def test_blank_views_exclude_children_option(self):
         response = self.client.get(
             reverse(
-                "api-resource-blank",
+                "arches_querysets:api-resource-blank",
                 kwargs={"graph": "datatype_lookups"},
             )
         )
@@ -169,7 +169,7 @@ class RestFrameworkTests(GraphTestCase):
 
         response = self.client.get(
             reverse(
-                "api-resource-blank",
+                "arches_querysets:api-resource-blank",
                 kwargs={"graph": "datatype_lookups"},
             ),
             QUERY_STRING="exclude_children=true",
@@ -178,7 +178,7 @@ class RestFrameworkTests(GraphTestCase):
 
         response = self.client.get(
             reverse(
-                "api-tile-blank",
+                "arches_querysets:api-tile-blank",
                 kwargs={"graph": "datatype_lookups", "nodegroup_alias": "datatypes_1"},
             )
         )
@@ -186,7 +186,7 @@ class RestFrameworkTests(GraphTestCase):
 
         response = self.client.get(
             reverse(
-                "api-tile-blank",
+                "arches_querysets:api-tile-blank",
                 kwargs={
                     "graph": "datatype_lookups",
                     "nodegroup_alias": "datatypes_1",
@@ -201,7 +201,7 @@ class RestFrameworkTests(GraphTestCase):
 
         response = self.client.get(
             reverse(
-                "api-resources",
+                "arches_querysets:api-resources",
                 kwargs={"graph": "datatype_lookups"},
             ),
             # Additional lookups tested in test_lookups.py
@@ -215,7 +215,7 @@ class RestFrameworkTests(GraphTestCase):
 
         response = self.client.get(
             reverse(
-                "api-tiles",
+                "arches_querysets:api-tiles",
                 kwargs={"graph": "datatype_lookups", "nodegroup_alias": "datatypes_1"},
             ),
             QUERY_STRING=f"aliased_data__{node_alias}__any_lang_icontains=forty",


### PR DESCRIPTION
Moves include of arches.urls into a separate urls file (arches_querysets_url) for use when querysets is being run as a project rather than an app. When run as an app, only queryset specific urls are available to the host project.