### PR TITLE
Allow key and index transforms via values() and values_list()

### DIFF
--- a/tests/test_aggregates.py
+++ b/tests/test_aggregates.py
@@ -10,9 +10,7 @@ class AggregateTests(GraphTestCase):
 
         # Edit the resource that usually has None in all nodes to have a value of 43.
         # Fetch it since cls.resource_none was not fetched via get_tiles() :/
-        resource2 = ResourceTileTree.get_tiles("datatype_lookups").get(
-            pk=self.resource_none.pk
-        )
+        resource2 = self.resources.get(pk=self.resource_none.pk)
         resource2.aliased_data.datatypes_1.aliased_data.number_alias = 43
         resource2.aliased_data.datatypes_n[0].aliased_data.number_alias_n = 43
         resource2.save(force_admin=True)

--- a/tests/test_lookups.py
+++ b/tests/test_lookups.py
@@ -2,7 +2,7 @@ from arches_querysets.models import ResourceTileTree, TileTree
 from arches_querysets.utils.tests import GraphTestCase
 
 
-class GenericLookupTests(GraphTestCase):
+class LookupTestCase(GraphTestCase):
     def setUp(self):
         self.resources = ResourceTileTree.get_tiles("datatype_lookups")
         self.tiles_1 = TileTree.get_tiles(
@@ -12,6 +12,8 @@ class GenericLookupTests(GraphTestCase):
             "datatype_lookups", nodegroup_alias="datatypes_n"
         )
 
+
+class GenericLookupTests(LookupTestCase):
     def test_cardinality_1(self):
         # Exact
         for lookup, value in [
@@ -71,8 +73,16 @@ class GenericLookupTests(GraphTestCase):
                 self.assertTrue(self.resources.values_list(node.alias))
                 self.assertTrue(self.tiles_n.values_list(node.alias))
 
+    def test_values_path_transforms(self):
+        self.assertTrue(
+            self.resources.values("resource_instance_list_alias__0__resourceId")
+        )
+        self.assertTrue(
+            self.resources.values_list("resource_instance_list_alias__0__resourceId")
+        )
 
-class NonLocalizedStringLookupTests(GenericLookupTests):
+
+class NonLocalizedStringLookupTests(LookupTestCase):
     def test_cardinality_1(self):
         self.assertTrue(
             self.resources.filter(non_localized_string_alias__contains="forty")
@@ -96,7 +106,7 @@ class NonLocalizedStringLookupTests(GenericLookupTests):
         )
 
 
-class LocalizedStringLookupTests(GenericLookupTests):
+class LocalizedStringLookupTests(LookupTestCase):
     def test_cardinality_1(self):
         for lookup, value in [
             ("string_alias__any_lang_startswith", "forty"),
@@ -138,7 +148,7 @@ class LocalizedStringLookupTests(GenericLookupTests):
                 self.assertFalse(self.resources.filter(**{lookup: value}))
 
 
-class ResourceInstanceLookupTests(GenericLookupTests):
+class ResourceInstanceLookupTests(LookupTestCase):
     def test_cardinality_1(self):
         for lookup, value in [
             ("resource_instance_alias__id", str(self.resource_42.pk)),

--- a/tests/test_lookups.py
+++ b/tests/test_lookups.py
@@ -1,3 +1,5 @@
+import uuid
+
 from arches_querysets.models import ResourceTileTree, TileTree
 from arches_querysets.utils.tests import GraphTestCase
 
@@ -74,12 +76,17 @@ class GenericLookupTests(LookupTestCase):
                 self.assertTrue(self.tiles_n.values_list(node.alias))
 
     def test_values_path_transforms(self):
-        self.assertTrue(
-            self.resources.values("resource_instance_list_alias__0__resourceId")
+        resources = self.resources.exclude(resource_instance_list_alias=None)
+        values = resources.values("resource_instance_list_alias__0__resourceId")
+        uuid_val = values[0]["resource_instance_list_alias__0__resourceId"]
+        # Implicitly test the result is a uuid
+        uuid.UUID(uuid_val)
+
+        values = resources.values_list(
+            "resource_instance_list_alias__0__resourceId", flat=True
         )
-        self.assertTrue(
-            self.resources.values_list("resource_instance_list_alias__0__resourceId")
-        )
+        uuid_val = values[0]
+        uuid.UUID(uuid_val)
 
 
 class NonLocalizedStringLookupTests(LookupTestCase):


### PR DESCRIPTION
Follow-up to #88, allow `.values_list("my_string_alias__en__value")` etc.