### PR TITLE
Improve extensibility by custom datatypes

### DIFF
--- a/arches_querysets/datatypes/datatypes.py
+++ b/arches_querysets/datatypes/datatypes.py
@@ -1,8 +1,19 @@
 import django.db.models
 
-from arches.app.datatypes import datatypes
+from arches.app.datatypes.datatypes import (
+    BooleanDataType,
+    DateDataType,
+    NonLocalizedStringDataType,
+    NumberDataType,
+)
 
 from arches_querysets.datatypes import *
+from arches_querysets.fields import (
+    ConceptListField,
+    LocalizedStringField,
+    ResourceInstanceField,
+    ResourceInstanceListField,
+)
 
 
 class DataTypeFactory(datatypes.DataTypeFactory):
@@ -24,13 +35,26 @@ class DataTypeFactory(datatypes.DataTypeFactory):
         if model_field := getattr(instance, "model_field", None):
             return model_field
         match instance:
-            case datatypes.NumberDataType():
+            case NumberDataType():
                 return django.db.models.FloatField(null=True)
-            case datatypes.DateDataType():
-                return django.db.models.DateField(null=True)
-            case datatypes.BooleanDataType():
+            case DateDataType():
+                return django.db.models.DateTimeField(null=True)
+            case BooleanDataType():
                 return django.db.models.BooleanField(null=True)
-            case datatypes.NonLocalizedStringDataType():
-                return django.db.models.CharField(null=True)
-            case _:
+            case NonLocalizedStringDataType():
+                return django.db.models.TextField(null=True)
+            case StringDataType():
+                return LocalizedStringField(null=True)
+            case ResourceInstanceListDataType():
+                # must precede ResourceInstanceDataType
+                return ResourceInstanceListField(null=True)
+            case ResourceInstanceDataType():
+                return ResourceInstanceField(null=True)
+            case ConceptListDataType():
+                return ConceptListField(null=True)
+            case ConceptDataType(), NodeValueDataType():
+                return django.db.models.UUIDField(null=True)
+            case URLDataType():
                 return django.db.models.JSONField(null=True)
+            case _:
+                return django.db.models.TextField(null=True)

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -314,6 +314,12 @@ class TileAliasedDataSerializer(serializers.ModelSerializer, NodeFetcherMixin):
         ret._graph_nodes = self._graph_nodes
         return ret
 
+    @classmethod
+    def register_custom_datatype_field(cls, model_field, serializer_field):
+        cls.serializer_field_mapping[model_field] = _wrap_serializer_field(
+            serializer_field
+        )
+
     def get_value(self, dictionary):
         """Avoid the branch that treats MultiPart data input as HTML."""
         return dictionary.get(self.field_name, empty)


### PR DESCRIPTION
Improve extensibility by custom datatypes (e.g. reference datatype) by:
- Removing hard-coded `DATATYPE_OUTPUT_FIELDS`
- Providing an interface to register a custom serializer, see example usage in sidecar PR to controlled lists