### PR TITLE
Add tests, safety, ensure edit log behavior is consistent on 7.6/8.0

### DIFF
--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -200,6 +200,13 @@ class TileTreeOperation:
         else:
             next_sort_order = max(t.sortorder or 0 for t in existing_tiles) + 1
 
+        if self.for_new_resource or (
+            isinstance(self.entry, ResourceInstance) and self.entry._state.adding
+        ):
+            exclude = ["resourceinstance"]
+        else:
+            exclude = []
+
         to_insert = set()
         to_update = set()
         to_delete = set()
@@ -222,7 +229,6 @@ class TileTreeOperation:
                 new_tile._incoming_tile = new_tile
                 if isinstance(container, TileModel):
                     new_tile.parenttile = container
-                exclude = ["resourceinstance"] if self.for_new_resource else []
                 new_tile.full_clean(exclude=exclude)
                 if new_tile.pk is None:
                     new_tile.pk = uuid.uuid4()

--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -11,11 +11,13 @@ from django.utils.translation import get_language, gettext as _
 from arches import VERSION as arches_version
 from arches.app.models.models import (
     CardXNodeXWidget,
+    EditLog,
     Language,
     Node,
-    TileModel,
     ResourceInstance,
+    TileModel,
 )
+from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile, TileValidationError
 
 from arches_querysets.datatypes.datatypes import DataTypeFactory
@@ -77,7 +79,7 @@ class TileTreeOperation:
                 # with the request and already instantiated to a fresh object.
                 grouping_node = [
                     node
-                    for node in entry.resourceinstance.graph.node_set.all()
+                    for node in entry.nodegroup.node_set.all()[0].graph.node_set.all()
                     if node.pk == node.nodegroup_id
                 ][0]
                 entry.nodegroup.grouping_node = grouping_node
@@ -86,21 +88,28 @@ class TileTreeOperation:
             self.nodegroups = []  # not necessary to populate.
             existing_tiles = getattr(self.entry, "_tile_trees", [])
 
+        self.for_new_resource = self.resourceid is None
+        if self.for_new_resource:
+            self.resourceid = uuid.uuid4()
+            if isinstance(self.entry, TileModel):
+                self.entry.resourceinstance_id = self.resourceid
+
+        if isinstance(self.entry, TileModel):
+            if self.for_new_resource:
+                self.graph = self.entry.nodegroup.node_set.all()[0].graph
+            else:
+                self.graph = self.entry.resourceinstance.graph
+        else:
+            self.graph = self.entry.graph
+
         self.grouping_nodes_by_nodegroup_id = self._get_grouping_node_lookup()
         self.existing_tiles_by_nodegroup_alias = defaultdict(list)
         for tile in existing_tiles:
             alias = tile.find_nodegroup_alias(self.grouping_nodes_by_nodegroup_id)
             self.existing_tiles_by_nodegroup_alias[alias].append(tile)
-        self.new_resource_created = bool(existing_tiles)
 
     def _get_grouping_node_lookup(self):
-        from arches_querysets.models import TileTree
-
-        if isinstance(self.entry, TileTree):
-            graph = self.entry.resourceinstance.graph
-        else:
-            graph = self.entry.graph
-        filters = Q(pk=F("nodegroup_id"), graph__slug=graph.slug)
+        filters = Q(pk=F("nodegroup_id"), graph__slug=self.graph.slug)
         # arches_version==9.0.0
         if arches_version >= (8, 0):
             filters &= Q(source_identifier=None)
@@ -213,7 +222,8 @@ class TileTreeOperation:
                 new_tile._incoming_tile = new_tile
                 if isinstance(container, TileModel):
                     new_tile.parenttile = container
-                new_tile.full_clean()
+                exclude = ["resourceinstance"] if self.for_new_resource else []
+                new_tile.full_clean(exclude=exclude)
                 if new_tile.pk is None:
                     new_tile.pk = uuid.uuid4()
                 to_insert.add(new_tile)
@@ -386,6 +396,30 @@ class TileTreeOperation:
             )
 
     def _save(self):
+        if self.for_new_resource:
+            instance = Resource(pk=self.resourceid, graph=self.graph)
+            instance.save(request=self.request, transaction_id=self.transaction_id)
+            # if entry tile needs saving, already in self.to_update or self.to_insert
+
+        # durable=True is a guard against any higher-level code trying to wrap in
+        # another transaction. Ideally durable=True would be removed, and any
+        # IntegrityErrors would not be ignored in after_update_all(), but we have
+        # some Arches projects that test with "incomplete" datasets with data
+        # integrity issues, so we can't do the natural thing (yet).
+        try:
+            self._perform_transaction()
+        except:
+            if self.for_new_resource:
+                # Manually manage failures instead of using transaction.atomic(), see:
+                # https://github.com/archesproject/arches/issues/12318
+                # Don't want to run model delete() which *creates* edit log entries.
+                EditLog.objects.filter(resourceinstanceid=instance.pk).delete()
+                Resource.objects.filter(pk=instance.pk).delete()
+            raise
+
+    def _perform_transaction(self):
+        from arches_querysets.models import ResourceTileTree
+
         # Instantiate proxy models for now, but TODO: expose this
         # functionality on vanilla models, and in bulk.
         tile_model_fields = Tile._meta.get_fields()
@@ -405,17 +439,12 @@ class TileTreeOperation:
             pk__in=[tile.pk for tile in self.to_delete]
         )
 
-        # durable=True is a guard against any higher-level code trying to wrap in
-        # another transaction. Ideally durable=True would be removed, and any
-        # IntegrityErrors would not be ignored in after_update_all(), but we have
-        # some Arches projects that test with "incomplete" datasets with data
-        # integrity issues, so we can't do the natural thing (yet).
         with transaction.atomic(durable=True):
-            if isinstance(self.entry, ResourceInstance):
-                super(ResourceInstance, self.entry).save(**self.save_kwargs)
-            # no else: if the entry point needs saving, it's already in
-            # self.to_update or self.to_insert
-
+            if not self.for_new_resource:
+                if isinstance(self.entry, ResourceTileTree):
+                    super(ResourceTileTree, self.entry).save(**self.save_kwargs)
+                elif isinstance(self.entry, ResourceInstance):
+                    self.entry.save(**self.save_kwargs)
             # Interact with the database in bulk as much as possible, but
             # run certain side effects from Tile.save() one-at-a-time until
             # proxy model methods can be refactored. Then run in bulk.
@@ -512,7 +541,7 @@ class TileTreeOperation:
                     newprovisionalvalue=insert_proxy._newprovisionalvalue,
                     provisional_edit_log_details=insert_proxy._provisional_edit_log_details,
                     transaction_id=self.transaction_id,
-                    new_resource_created=self.new_resource_created,
+                    new_resource_created=False,  # resource create edit log already saved
                     note=None,
                 )
             for update_proxy in update_proxies:

--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -214,6 +214,8 @@ class TileTreeOperation:
                 if isinstance(container, TileModel):
                     new_tile.parenttile = container
                 new_tile.full_clean()
+                if new_tile.pk is None:
+                    new_tile.pk = uuid.uuid4()
                 to_insert.add(new_tile)
             else:
                 original_tile_data_by_tile_id[existing_tile.pk] = {**existing_tile.data}

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -13,8 +13,7 @@ from rest_framework.fields import empty
 
 from arches import VERSION as arches_version
 from arches.app.models.fields.i18n import I18n_JSON, I18n_String
-from arches.app.models.models import EditLog, GraphModel, Node, NodeGroup
-from arches.app.models.resource import Resource
+from arches.app.models.models import GraphModel, Node, NodeGroup
 from arches.app.utils.betterJSONSerializer import JSONSerializer
 
 from arches_querysets.datatypes.datatypes import DataTypeFactory
@@ -652,7 +651,10 @@ class ArchesResourceSerializer(serializers.ModelSerializer, NodeFetcherMixin):
                 "default": None,
                 "allow_null": True,
             },
-            "graph": {"allow_null": True},
+            # TODO (arches_version): when Arches 8.0 is the lowest supported
+            # version, "required": False can be removed, by relying on the
+            # underlying blank=True on model.
+            "graph": {"allow_null": True, "required": False},
         }
 
     def __init__(

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -607,35 +607,11 @@ class ArchesTileSerializer(serializers.ModelSerializer, NodeFetcherMixin):
                     node__alias=self.nodegroup_alias,
                 ).values("pk")[:1]
             )
+            .values("entry_nodegroup_id")
             .get()
         )
-        resource, resource_created = self.create_resource_if_missing(
-            validated_data, graph
-        )
-        validated_data["nodegroup_id"] = graph.entry_nodegroup_id
-        try:
-            created = super().create(validated_data)
-        except:
-            if resource_created:
-                # Manually manage failures instead of using transaction.atomic(), see:
-                # https://github.com/archesproject/arches/issues/12318
-                # Don't want to run model delete() which *creates* edit log entries.
-                EditLog.objects.filter(resourceinstanceid=resource.pk).delete()
-                Resource.objects.filter(pk=resource.pk).delete()
-            raise
-        return created
-
-    def create_resource_if_missing(self, validated_data, graph):
-        if instance := validated_data.get("resourceinstance"):
-            return instance, False
-        # Would like to do the following, but we don't yet have a ResourceTileTree.save()
-        # method handling a fast path for empty creates:
-        # ResourceSubclass = self.fields["resourceinstance"].queryset.model
-        # So hardcode the Resource(Proxy)Model for now.
-        instance = Resource(graph=graph)
-        instance.save(request=validated_data["__request"])
-        validated_data["resourceinstance"] = instance
-        return instance, True
+        validated_data["nodegroup_id"] = graph["entry_nodegroup_id"]
+        return super().create(validated_data)
 
 
 class ArchesSingleNodegroupSerializer(ArchesTileSerializer):
@@ -669,7 +645,13 @@ class ArchesResourceSerializer(serializers.ModelSerializer, NodeFetcherMixin):
             "resource_instance_lifecycle_state",
         )
         extra_kwargs = {
-            "resourceinstanceid": {"initial": None, "allow_null": True},
+            # Cancel the underlying default so it can be managed by
+            # TileTreeOperation.for_new_resource
+            "resourceinstanceid": {
+                "initial": None,
+                "default": None,
+                "allow_null": True,
+            },
             "graph": {"allow_null": True},
         }
 
@@ -718,30 +700,10 @@ class ArchesResourceSerializer(serializers.ModelSerializer, NodeFetcherMixin):
         return attrs
 
     def create(self, validated_data):
-        # TODO: we probably want a queryset method to do one-shot
-        # creates with tile data
-        without_tile_data = validated_data.copy()
-        without_tile_data.pop("aliased_data", None)
-        # TODO: decide on "blank" interface.
-        instance_without_tile_data = self.Meta.model.mro()[1](**without_tile_data)
-        instance_without_tile_data.save()
-        instance_from_factory = self.Meta.model.get_tiles(
-            graph_slug=self.graph_slug,
-            as_representation=True,
-        ).get(pk=instance_without_tile_data.pk)
-        # TODO: decide whether to override update() instead of using partial().
-        instance_from_factory.save = partial(
-            instance_from_factory.save, request=self.context["request"]
-        )
-        try:
-            updated = self.update(instance_from_factory, validated_data)
-        except:
-            # Manually manage failures instead of using transaction.atomic(), see
-            # https://github.com/archesproject/arches/issues/12318
-            EditLog.objects.filter(resourceinstanceid=instance_from_factory.pk).delete()
-            Resource.objects.filter(pk=instance_from_factory.pk).delete()
-            raise
-        return updated
+        # Provide some additional context to ResourceTileTree.__init__()
+        validated_data["__request"] = self.context["request"]
+        validated_data["__as_representation"] = True
+        return super().create(validated_data)
 
     def get_graph_has_different_publication(self, obj):
         # arches_version==9.0.0

--- a/arches_querysets/rest_framework/view_mixins.py
+++ b/arches_querysets/rest_framework/view_mixins.py
@@ -100,6 +100,7 @@ class ArchesModelAPIMixin:
             "graph_slug": self.graph_slug,
             "graph_nodes": self.graph_nodes or self._find_graph_nodes(),
             "nodegroup_alias": self.nodegroup_alias,
+            "fill_blanks": self.fill_blanks,
         }
         if not ret.get("nodegroup_alias_lookup"):
             ret["nodegroup_alias_lookup"] = {

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -189,15 +189,11 @@ class RestFrameworkTests(GraphTestCase):
 
         edits = EditLog.objects.filter(
             resourceinstanceid=response.json()["resourceinstanceid"],
-        )
-        self.assertSequenceEqual(
-            edits.values_list("edittype", flat=True).order_by("edittype"),
-            ["create", "tile create", "tile create"],
-        )
+        ).order_by("edittype")
         self.assertEqual(
-            len(set(edits.values_list("transactionid", flat=True))),
-            1,
+            [edit.edittype for edit in edits], ["create", "tile create", "tile create"]
         )
+        self.assertEqual(len(set([edit.transactionid for edit in edits])), 1)
 
     def test_update_tile(self):
         update_url = reverse(

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -149,9 +149,6 @@ class RestFrameworkTests(GraphTestCase):
             ["create", "tile create", "tile create"],
         )
 
-    @unittest.skipIf(
-        arches_version < (8, 0), reason="models Arches 8+ usage omitting graph"
-    )
     def test_create_nested_tiles_for_new_resource_via_resource_serializer(self):
         self.client.login(username="dev", password="dev")
         create_url = reverse(

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -315,6 +315,20 @@ class RestFrameworkTests(GraphTestCase):
         )
         self.assertNotContains(response, "datatypes_1_child")
 
+    def test_fill_blanks_option(self):
+        self.resource_42.tilemodel_set.all().delete()
+        response = self.client.get(
+            reverse(
+                "arches_querysets:api-resource",
+                kwargs={"graph": "datatype_lookups", "pk": str(self.resource_42.pk)},
+            ),
+            QUERY_STRING="fill_blanks=true",
+        )
+        parent_data = response.json()["aliased_data"]["datatypes_1"]
+        self.assertIsNone(parent_data["tileid"])
+        child_data = parent_data["aliased_data"]["dataypes_1_child"]
+        self.assertIsNone(child_data["tileid"])
+
     @patch(
         "arches.app.models.models.UserProfile.viewable_nodegroups",
         MUTABLE_PERMITTED_NODEGROUPS,

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -326,7 +326,7 @@ class RestFrameworkTests(GraphTestCase):
         )
         parent_data = response.json()["aliased_data"]["datatypes_1"]
         self.assertIsNone(parent_data["tileid"])
-        child_data = parent_data["aliased_data"]["dataypes_1_child"]
+        child_data = parent_data["aliased_data"]["datatypes_1_child"]
         self.assertIsNone(child_data["tileid"])
 
     @patch(

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -268,6 +268,15 @@ class RestFrameworkTests(GraphTestCase):
         )
         self.assertNotIn("datatypes_1_child", serializer.data["aliased_data"])
 
+    def test_blank_views_tile_id(self):
+        response = self.client.get(
+            reverse(
+                "arches_querysets:api-tile-blank",
+                kwargs={"graph": "datatype_lookups", "nodegroup_alias": "datatypes_1"},
+            )
+        )
+        self.assertIsNone(response.json()["tileid"])
+
     def test_blank_views_exclude_children_option(self):
         response = self.client.get(
             reverse(

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -187,13 +187,16 @@ class RestFrameworkTests(GraphTestCase):
         )
         self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
 
+        edits = EditLog.objects.filter(
+            resourceinstanceid=response.json()["resourceinstanceid"],
+        )
         self.assertSequenceEqual(
-            EditLog.objects.filter(
-                resourceinstanceid=response.json()["resourceinstanceid"],
-            )
-            .values_list("edittype", flat=True)
-            .order_by("edittype"),
+            edits.values_list("edittype", flat=True).order_by("edittype"),
             ["create", "tile create", "tile create"],
+        )
+        self.assertEqual(
+            len(set(edits.values_list("transactionid", flat=True))),
+            1,
         )
 
     def test_update_tile(self):


### PR DESCRIPTION
Before, we had "overactive" code nulling out tile ids in service of the "blank" routes.