### PR TITLE
removes empty string return

### DIFF
--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -618,7 +618,6 @@ class TileTree(TileModel, AliasedDataMixin):
             ret["details"] = []
         if ret["display_value"] in empty_display_values:
             # Future: upstream this into datatype methods (another hook?)
-            # ret["display_value"] = _("(Empty)")
             ret["display_value"] = ""
         return ret
 

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -618,7 +618,8 @@ class TileTree(TileModel, AliasedDataMixin):
             ret["details"] = []
         if ret["display_value"] in empty_display_values:
             # Future: upstream this into datatype methods (another hook?)
-            ret["display_value"] = _("(Empty)")
+            # ret["display_value"] = _("(Empty)")
+            ret["display_value"] = ""
         return ret
 
     def set_aliased_data(self, node, node_value, datatype_contexts=None):

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -59,7 +59,7 @@ class DatatypeRepresentationTests(GraphTestCase):
                     value = getattr(resource_data, lookup)
                     self.assertEqual(value.get("display_value"), representation)
                     value = getattr(resource_data_none, lookup)
-                    self.assertEqual(value.get("display_value"), "(Empty)")
+                    self.assertEqual(value.get("display_value"), "")
 
     def test_as_representation_details(self):
         detail_values = {


### PR DESCRIPTION
having this return an `(Empty)` string is problematic when attempting to rebuild the blank object on the frontend.