### PR TITLE
Add missing prefetch for widget configs

### DIFF
--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -106,16 +106,16 @@ class TileTreeOperation:
             filters &= Q(source_identifier=None)
             return {
                 node.pk: node
-                for node in Node.objects.filter(filters).select_related(
-                    "nodegroup__grouping_node__nodegroup__parentnodegroup"
-                )
+                for node in Node.objects.filter(filters)
+                .select_related("nodegroup__grouping_node__nodegroup__parentnodegroup")
+                .prefetch_related("nodegroup__node_set__cardxnodexwidget_set")
             }
         else:
             ret = {
                 node.pk: node
-                for node in Node.objects.filter(filters).select_related(
-                    "nodegroup__parentnodegroup"
-                )
+                for node in Node.objects.filter(filters)
+                .select_related("nodegroup__parentnodegroup")
+                .prefetch_related("nodegroup__node_set__cardxnodexwidget_set")
             }
             for node_id, node in ret.items():
                 node.nodegroup.grouping_node = ret[node_id]

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -12,12 +12,7 @@ from django.db import models
 from django.utils.translation import gettext as _
 
 from arches import VERSION as arches_version
-from arches.app.models.models import (
-    GraphModel,
-    Node,
-    ResourceInstance,
-    TileModel,
-)
+from arches.app.models.models import GraphModel, ResourceInstance, TileModel
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
 from arches.app.utils.betterJSONSerializer import JSONSerializer

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -52,7 +52,7 @@ class RestFrameworkTests(GraphTestCase):
         )
 
         # The response includes the context.
-        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
         self.assertIn("aliased_data", response.json())
         self.assertEqual(
             response.json()["aliased_data"]["string_alias_n"],
@@ -64,8 +64,6 @@ class RestFrameworkTests(GraphTestCase):
                 "details": [],
             },
         )
-        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
-
         self.assertSequenceEqual(
             EditLog.objects.filter(
                 resourceinstanceid=response.json()["resourceinstance"],


### PR DESCRIPTION
This should help a little, there were N+1 queries here fetching this widget config:

https://github.com/archesproject/arches-querysets/blob/20a419f7d29aff3ea05c3abff76dcfa5d724567f/arches_querysets/models.py#L574

Once Django 6.1 is out with fetch modes, a lot of these manual `prefetch_related()` calls can be replaced. 🤞 