### PR TITLE
Fix tests

### DIFF
--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -106,16 +106,16 @@ class TileTreeOperation:
             filters &= Q(source_identifier=None)
             return {
                 node.pk: node
-                for node in Node.objects.filter(filters).select_related(
-                    "nodegroup__grouping_node__nodegroup__parentnodegroup"
-                )
+                for node in Node.objects.filter(filters)
+                .select_related("nodegroup__grouping_node__nodegroup__parentnodegroup")
+                .prefetch_related("nodegroup__node_set__cardxnodexwidget_set")
             }
         else:
             ret = {
                 node.pk: node
-                for node in Node.objects.filter(filters).select_related(
-                    "nodegroup__parentnodegroup"
-                )
+                for node in Node.objects.filter(filters)
+                .select_related("nodegroup__parentnodegroup")
+                .prefetch_related("nodegroup__node_set__cardxnodexwidget_set")
             }
             for node_id, node in ret.items():
                 node.nodegroup.grouping_node = ret[node_id]

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -12,12 +12,7 @@ from django.db import models
 from django.utils.translation import gettext as _
 
 from arches import VERSION as arches_version
-from arches.app.models.models import (
-    GraphModel,
-    Node,
-    ResourceInstance,
-    TileModel,
-)
+from arches.app.models.models import GraphModel, ResourceInstance, TileModel
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
 from arches.app.utils.betterJSONSerializer import JSONSerializer

--- a/arches_querysets/utils/tests.py
+++ b/arches_querysets/utils/tests.py
@@ -220,7 +220,11 @@ class GraphTestCase(TestCase):
             "url": {"url": "http://arthurdent.com", "url_label": ""},
             "boolean": False,
             "number": 7,
-            "date": "1979-10-12T00:00:00.000-05:00",
+            "date": (
+                "1979-10-12"
+                if arches_version > (8, 0)
+                else "1979-10-12T00:00:00.000-05:00"
+            ),
             # "resource-instance": None,
             # "resource-instance-list": [],
             # "concept": None,

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -52,7 +52,7 @@ class RestFrameworkTests(GraphTestCase):
         )
 
         # The response includes the context.
-        self.assertEqual(response.status_code, HTTPStatus.CREATED)
+        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
         self.assertIn("aliased_data", response.json())
         self.assertEqual(
             response.json()["aliased_data"]["string_alias_n"],
@@ -64,8 +64,6 @@ class RestFrameworkTests(GraphTestCase):
                 "details": [],
             },
         )
-        self.assertEqual(response.status_code, HTTPStatus.CREATED, response.content)
-
         self.assertSequenceEqual(
             EditLog.objects.filter(
                 resourceinstanceid=response.json()["resourceinstance"],

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -44,7 +44,7 @@ class SaveTileTests(GraphTestCase):
         self.resource_42.refresh_from_db()
         self.resource_42.fill_blanks()
         # Saving a blank tile should populate default values if defaults are defined.
-        self.resource_42.save()
+        self.resource_42.save(force_admin=True)
         self.assert_default_values_present(self.resource_42)
 
         # fill_blanks gives an unsaved empty tile, but we also need to test that inserting
@@ -57,7 +57,7 @@ class SaveTileTests(GraphTestCase):
         for node in self.resource_42.aliased_data.datatypes_1.data:
             self.resource_42.aliased_data.datatypes_1.data[node] = None
         # Save should stock defaults
-        self.resource_42.aliased_data.datatypes_1.save()
+        self.resource_42.aliased_data.datatypes_1.save(force_admin=True)
         self.assert_default_values_present(self.resource_42)
 
     def test_fill_blanks(self):
@@ -93,7 +93,7 @@ class SaveTileTests(GraphTestCase):
             # TODO(arches_version==9.0.0): in Arches 8+, data={} can be removed.
             data={},
         )
-        new_child_tile.save()
+        new_child_tile.save(force_admin=True)
         # The parent property holds the richer TileTree
         self.assertIsInstance(new_child_tile.parent, TileTree)
         # The regular Django field is untouched (still a vanilla TileModel)
@@ -101,10 +101,11 @@ class SaveTileTests(GraphTestCase):
         self.assertIsInstance(new_child_tile.parenttile, TileModel)
 
     def test_cardinality_error(self):
+        tt = TileTree(
+            nodegroup=self.nodegroup_1, resourceinstance=self.resource_42, data={}
+        )
         with self.assertRaises(ValidationError) as ctx:
-            TileTree.objects.create(
-                nodegroup=self.nodegroup_1, resourceinstance=self.resource_42, data={}
-            )
+            tt.save(force_admin=True)
         self.assertEqual(
             ctx.exception.message_dict, {"datatypes_1": ["Tile Cardinality Error"]}
         )


### PR DESCRIPTION
Closes #136

- Update tests for permission fixes in core

force_admin=True is a development shortcut useful in tests
to avoid setting up a user with resource editor permissions
and attaching it to a request. Without a user one way or the
other, the default is the anonymous user, which recently got
its nodegroups for editing permissions revoked.

Refs https://github.com/archesproject/arches/commit/1c2f647

- Update tests for date format change in core

Refs https://github.com/archesproject/arches/issues/12480

***
Not sure if y'all want this targeting 1.0 or 1.1?