### PR TITLE
ensures that Tile model delete method is used on delete

### DIFF
--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -344,7 +344,7 @@ class TileTree(TileModel, AliasedDataMixin):
         edit logging, search index cleanup, and datatype post-delete
         side effects all run."""
         tile = Tile.objects.get(pk=self.pk)
-        tile.delete(*args, request=request, **kwargs)
+        return tile.delete(*args, request=request, **kwargs)
 
     def save(
         self, *, request=None, index=True, partial=True, force_admin=False, **kwargs

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -339,6 +339,13 @@ class TileTree(TileModel, AliasedDataMixin):
     def sealed(self, value):
         self._sealed = value
 
+    def delete(self, *args, request=None, **kwargs):
+        """Delegate to Tile.delete() so that function hooks (__preDelete),
+        edit logging, search index cleanup, and datatype post-delete
+        side effects all run."""
+        tile = Tile.objects.get(pk=self.pk)
+        tile.delete(*args, request=request, **kwargs)
+
     def save(
         self, *, request=None, index=True, partial=True, force_admin=False, **kwargs
     ):

--- a/arches_querysets/rest_framework/view_mixins.py
+++ b/arches_querysets/rest_framework/view_mixins.py
@@ -265,6 +265,9 @@ class ArchesModelAPIMixin:
     def perform_update(self, serializer):
         self.validate_tile_data_and_save(serializer)
 
+    def perform_destroy(self, instance):
+        instance.delete(request=self.request)
+
     @staticmethod
     def flatten_validation_errors(error):
         """DRF's ValidationError doesn't really handle nesting, so unpack


### PR DESCRIPTION
fixes #169 
By using the Tile delete method, we ensure that graph functions are being called on delete.  Previously, these were being bypassed