### PR TITLE
Revert "fixes version number comparisons (#171)"

### DIFF
--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -8,10 +8,7 @@ from django.db import ProgrammingError, transaction
 from django.db.models import F, Q, OuterRef, Exists
 from django.utils.translation import get_language, gettext as _
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.models.models import (
     CardXNodeXWidget,
     EditLog,
@@ -77,7 +74,7 @@ class TileTreeOperation:
                 .order_by("sortorder")
             )
             # arches_version==9.0.0
-            if arches_version < Version("8.0"):
+            if arches_version < (8, 0):
                 # Cannot supply this too early, as nodegroup might be included
                 # with the request and already instantiated to a fresh object.
                 grouping_node = [
@@ -114,7 +111,7 @@ class TileTreeOperation:
     def _get_grouping_node_lookup(self):
         filters = Q(pk=F("nodegroup_id"), graph__slug=self.graph.slug)
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             filters &= Q(source_identifier=None)
             return {
                 node.pk: node
@@ -276,7 +273,7 @@ class TileTreeOperation:
         nodes = grouping_node.nodegroup.node_set.all()
         for tile in to_insert | to_update:
             # arches_version==9.0.0
-            if arches_version >= Version("8.0"):
+            if arches_version >= (8, 0):
                 children = tile.nodegroup.children.all()
             else:
                 children = tile.nodegroup.nodegroup_set.all()

--- a/arches_querysets/datatypes/file.py
+++ b/arches_querysets/datatypes/file.py
@@ -1,9 +1,6 @@
 from django.utils.translation import get_language
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.datatypes import datatypes
 from arches.app.models import models
 from arches.app.models.models import File
@@ -30,7 +27,7 @@ class FileListDataType(datatypes.FileListDataType):
             languages = models.Language.objects.all()
         language = get_language()
         # arches == 9.0.0 - remove the stringifieid_list in favor of the 8.1.0 logic
-        if arches_version < Version("8.1"):
+        if arches_version < (8, 1):
             original_value = value
             if isinstance(value, str):
                 stringified_list = value

--- a/arches_querysets/datatypes/resource_types.py
+++ b/arches_querysets/datatypes/resource_types.py
@@ -2,10 +2,7 @@ import logging
 import uuid
 from itertools import chain
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.datatypes import datatypes
 from arches.app.models import models
 from django.utils.translation import get_language
@@ -77,7 +74,7 @@ class ResourceInstanceDataType(datatypes.ResourceInstanceDataType):
         related_resources = []
 
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             relations = resource.from_resxres.all()
         else:
             relations = resource.resxres_resource_instance_ids_from.all()
@@ -92,7 +89,7 @@ class ResourceInstanceDataType(datatypes.ResourceInstanceDataType):
             target_resource_id = uuid.UUID(inner_val["resourceId"])
             if not relations:
                 # arches_version==9.0.0
-                if arches_version >= Version("8.0"):
+                if arches_version >= (8, 0):
                     relations = models.ResourceXResource.objects.filter(
                         to_resource_id=target_resource_id
                     ).select_related("to_resource")
@@ -105,7 +102,7 @@ class ResourceInstanceDataType(datatypes.ResourceInstanceDataType):
                 to_resource_id = (
                     relation.resourceinstanceidto_id
                     # arches_version==9.0.0
-                    if arches_version < Version("8.0")
+                    if arches_version < (8, 0)
                     else relation.to_resource_id
                 )
                 if to_resource_id == target_resource_id:
@@ -113,7 +110,7 @@ class ResourceInstanceDataType(datatypes.ResourceInstanceDataType):
                         to_resource = (
                             relation.resourceinstanceidto
                             # arches_version==9.0.0
-                            if arches_version < Version("8.0")
+                            if arches_version < (8, 0)
                             else relation.to_resource
                         )
                         if to_resource is None:

--- a/arches_querysets/models.py
+++ b/arches_querysets/models.py
@@ -12,10 +12,7 @@ from django.core.exceptions import (
 from django.db import models
 from django.utils.translation import gettext as _
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.models.models import GraphModel, ResourceInstance, TileModel
 from arches.app.models.resource import Resource
 from arches.app.models.tile import Tile
@@ -84,7 +81,7 @@ class AliasedDataMixin:
         # so we can retrieve aliased data from the queryset cache.
         from_queryset = from_queryset.filter(pk=self.pk)
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             # Patch out filter(pk=...) so that when refresh_from_db() calls get(),
             # it populates the cache. TODO: ask on forum about happier path.
             from_queryset.filter = lambda pk=None: from_queryset
@@ -156,7 +153,7 @@ class ResourceTileTree(ResourceInstance, AliasedDataMixin):
         """
         # arches_version==9.0.0
         if (
-            arches_version >= Version("8.0")
+            arches_version >= (8, 0)
             and self.graph_publication_id
             and (self.graph_publication_id != self.graph.publication_id)
         ):
@@ -279,7 +276,7 @@ class ResourceTileTree(ResourceInstance, AliasedDataMixin):
                 proxy_resource.index()
 
         # arches_version==9.0.0
-        if arches_version < Version("8.0") and request and for_new_resource:
+        if arches_version < (8, 0) and request and for_new_resource:
             self.save_edit(
                 user=request.user,
                 transaction_id=operation.transaction_id,
@@ -358,7 +355,7 @@ class TileTree(TileModel, AliasedDataMixin):
         """
         # arches_version==9.0.0
         if (
-            arches_version >= Version("8.0")
+            arches_version >= (8, 0)
             and self.resourceinstance_id
             and self.resourceinstance.graph_publication_id
             and (
@@ -372,7 +369,7 @@ class TileTree(TileModel, AliasedDataMixin):
         # Mimic some computations trapped on TileModel.save().
         # arches_version==9.0.0
         if (
-            arches_version >= Version("8.0")
+            arches_version >= (8, 0)
             and self.sortorder is None
             or self.is_fully_provisional()
         ):
@@ -432,7 +429,7 @@ class TileTree(TileModel, AliasedDataMixin):
 
     def find_nodegroup_alias(self, grouping_node_lookup=None):
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             if grouping_node_lookup:
                 self.nodegroup.grouping_node = grouping_node_lookup[self.nodegroup_id]
             return super().find_nodegroup_alias()
@@ -483,7 +480,7 @@ class TileTree(TileModel, AliasedDataMixin):
                     pass
 
         # arches_version==9.0.0
-        if arches_version < Version("8.0"):
+        if arches_version < (8, 0):
             # Simulate the default supplied by v8.
             tile.data = {}
 
@@ -598,7 +595,7 @@ class TileTree(TileModel, AliasedDataMixin):
             children = (
                 nodegroup.children.all()
                 # arches_version==9.0.0
-                if arches_version >= Version("8.0")
+                if arches_version >= (8, 0)
                 else nodegroup.nodegroup_set.all()
             )
             for child_nodegroup in children:

--- a/arches_querysets/querysets.py
+++ b/arches_querysets/querysets.py
@@ -8,10 +8,7 @@ from django.db.models.query import ModelIterable
 from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.models.models import Node
 
 from arches_querysets.datatypes.datatypes import DataTypeFactory
@@ -74,7 +71,7 @@ class TileTreeManager(models.Manager):
     def get_queryset(self):
         qs = super().get_queryset().select_related("resourceinstance")
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             # TODO: could get this once?
             qs = qs.prefetch_related("resourceinstance__from_resxres__to_resource")
             qs = qs.select_related("nodegroup__grouping_node")
@@ -141,7 +138,7 @@ class TileTreeQuerySet(NodeAliasValuesMixin, models.QuerySet):
             # by providing a `nodes` argument doing the same query.
             filters = models.Q(graph__slug=graph_slug)
             # arches_version==9.0.0
-            if arches_version >= Version("8.0"):
+            if arches_version >= (8, 0):
                 filters &= models.Q(source_identifier=None)
             nodes = (
                 Node.objects.filter(filters)
@@ -155,7 +152,7 @@ class TileTreeQuerySet(NodeAliasValuesMixin, models.QuerySet):
         alias_expressions = generate_node_alias_expressions(self.model, nodes)
 
         # arches_version==9.0.0
-        if arches_version < Version("8.0"):
+        if arches_version < (8, 0):
             msg = "arches-querysets requires all nodes to have an alias."
             assert None not in alias_expressions, msg
 
@@ -187,7 +184,7 @@ class TileTreeQuerySet(NodeAliasValuesMixin, models.QuerySet):
             qs = qs.prefetch_related(
                 models.Prefetch(
                     # arches_version==9.0.0
-                    "children" if arches_version >= Version("8.0") else "tilemodel_set",
+                    "children" if arches_version >= (8, 0) else "tilemodel_set",
                     queryset=child_tile_query,
                     # Using to_attr ensures the query results materialize into
                     # TileTree objects rather than TileModel objects. This isn't
@@ -292,7 +289,7 @@ class TileTreeQuerySet(NodeAliasValuesMixin, models.QuerySet):
         child_nodegroups = (
             getattr(tile.nodegroup, "children")
             # arches_version==9.0.0
-            if arches_version >= Version("8.0")
+            if arches_version >= (8, 0)
             else getattr(tile.nodegroup, "nodegroup_set")
         )
         for child_nodegroup in child_nodegroups.all():
@@ -402,7 +399,7 @@ class ResourceTileTreeQuerySet(NodeAliasValuesMixin, models.QuerySet):
             # by providing a `nodes` argument doing the same query.
             filters = models.Q(graph__slug=graph_slug)
             # arches_version==9.0.0
-            if arches_version >= Version("8.0"):
+            if arches_version >= (8, 0):
                 filters &= models.Q(source_identifier=None)
             nodes = (
                 Node.objects.filter(filters)
@@ -421,7 +418,7 @@ class ResourceTileTreeQuerySet(NodeAliasValuesMixin, models.QuerySet):
         else:
             filters = models.Q(graph__slug=graph_slug)
             # arches_version==9.0.0
-            if arches_version >= Version("8.0"):
+            if arches_version >= (8, 0):
                 filters &= models.Q(graph__source_identifier=None)
             qs = self.filter(filters)
 
@@ -626,7 +623,7 @@ class GraphWithPrefetchingQuerySet(models.QuerySet):  # pragma: no cover
             user=user,
             notes=_("Graph created."),
         )
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             graph.create_draft_graph()
 
         # ensures entity returned matches database entity
@@ -639,7 +636,7 @@ class GraphWithPrefetchingQuerySet(models.QuerySet):  # pragma: no cover
             qs = qs.filter(resourceinstance__in=resource_ids)
         elif graph_slug:
             # arches_version==9.0.0
-            if arches_version >= Version("8.0"):
+            if arches_version >= (8, 0):
                 qs = qs.filter(slug=graph_slug, source_identifier=None)
             else:
                 qs = qs.filter(slug=graph_slug)
@@ -647,7 +644,7 @@ class GraphWithPrefetchingQuerySet(models.QuerySet):  # pragma: no cover
             raise ValueError("graph_slug or resource_ids must be provided")
 
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             children = "children"
         else:
             children = "nodegroup_set"

--- a/arches_querysets/rest_framework/serializers.py
+++ b/arches_querysets/rest_framework/serializers.py
@@ -11,10 +11,7 @@ from rest_framework import renderers
 from rest_framework import serializers
 from rest_framework.fields import empty
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.models.fields.i18n import I18n_JSON, I18n_String
 from arches.app.models.models import GraphModel, Node, NodeGroup
 from arches.app.utils.betterJSONSerializer import JSONSerializer
@@ -178,7 +175,7 @@ class NodeFetcherMixin:
         node_filters = models.Q(graph__slug=self.graph_slug, nodegroup__isnull=False)
         children = "nodegroup_set"
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             node_filters &= models.Q(source_identifier=None)
             children = "children"
 
@@ -387,7 +384,7 @@ class TileAliasedDataSerializer(serializers.ModelSerializer, NodeFetcherMixin):
             child_query = (
                 self._root_node.nodegroup.children
                 # arches_version==9.0.0
-                if arches_version >= Version("8.0")
+                if arches_version >= (8, 0)
                 else self._root_node.nodegroup.nodegroup_set
             )
             flat_node_lookup = {node.pk: node for node in self.context["graph_nodes"]}
@@ -621,7 +618,7 @@ class ArchesTileSerializer(serializers.ModelSerializer, NodeFetcherMixin):
         if ret.get("tileid", object()) is None:
             ret["tileid"] = uuid.uuid4()
         # arches_version==9.0.0
-        if arches_version < Version("8.0"):
+        if arches_version < (8, 0):
             # Simulate field default provided by Arches 8+.
             ret["data"] = {}
         return ret
@@ -640,7 +637,7 @@ class ArchesTileSerializer(serializers.ModelSerializer, NodeFetcherMixin):
         validated_data["__as_representation"] = True
         graph_filters = models.Q(slug=self.graph_slug)
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             graph_filters &= models.Q(source_identifier=None)
         graph = (
             GraphModel.objects.filter(graph_filters)
@@ -727,7 +724,7 @@ class ArchesResourceSerializer(serializers.ModelSerializer, NodeFetcherMixin):
         ret = super().build_relational_field(field_name, relation_info)
         # arches_version==9.0.0
         if field_name == "graph":
-            if arches_version >= Version("8.0"):
+            if arches_version >= (8, 0):
                 ret[1]["queryset"] = ret[1]["queryset"].filter(
                     slug=self.graph_slug, source_identifier=None
                 )
@@ -768,7 +765,7 @@ class ArchesResourceSerializer(serializers.ModelSerializer, NodeFetcherMixin):
 
     def get_graph_has_different_publication(self, obj):
         # arches_version==9.0.0
-        if arches_version < Version("8.0"):
+        if arches_version < (8, 0):
             return False
         return obj.graph_publication_id and (
             obj.graph_publication_id != obj.graph.publication_id

--- a/arches_querysets/rest_framework/utils.py
+++ b/arches_querysets/rest_framework/utils.py
@@ -1,15 +1,12 @@
 from django.db import models
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.models.models import Node
 
 
 def get_nodegroup_alias_lookup(graph_slug):
     filters = models.Q(pk=models.F("nodegroup_id"), graph__slug=graph_slug)
     # arches_version==9.0.0
-    if arches_version >= Version("8.0"):
+    if arches_version >= (8, 0):
         filters &= models.Q(source_identifier=None)
     return {node.pk: node.alias for node in Node.objects.filter(filters).only("alias")}

--- a/arches_querysets/rest_framework/view_mixins.py
+++ b/arches_querysets/rest_framework/view_mixins.py
@@ -9,10 +9,7 @@ from rest_framework.exceptions import PermissionDenied, ValidationError
 from rest_framework.metadata import SimpleMetadata
 from rest_framework.settings import api_settings
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.models.models import Node, ResourceInstance, TileModel
 from arches.app.utils.permission_backend import (
     user_can_delete_resource,
@@ -77,7 +74,7 @@ class ArchesModelAPIMixin:
                     resource_ids=self.resource_ids,
                     as_representation=True,
                 ).select_related("graph")
-                if arches_version >= Version("8.0"):
+                if arches_version >= (8, 0):
                     qs = qs.select_related("resource_instance_lifecycle_state")
             elif issubclass(options.model, TileModel):
                 qs = options.model.get_tiles(
@@ -118,7 +115,7 @@ class ArchesModelAPIMixin:
         node_filters = Q(graph__slug=self.graph_slug, nodegroup__isnull=False)
         children = "nodegroup_set"
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             node_filters &= Q(source_identifier=None)
             children = "children"
 
@@ -148,7 +145,7 @@ class ArchesModelAPIMixin:
         options = self.serializer_class.Meta
         if issubclass(options.model, ResourceInstance):
             # arches_version==9.0.0
-            if arches_version >= Version("8.0"):
+            if arches_version >= (8, 0):
                 permission_kwargs = {"user": self.request.user, "resource": ret}
             else:
                 permission_kwargs = {"user": self.request.user, "resourceid": ret.pk}

--- a/arches_querysets/settings.py
+++ b/arches_querysets/settings.py
@@ -8,10 +8,7 @@ import semantic_version
 from datetime import datetime, timedelta
 from django.utils.translation import gettext_lazy as _
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 
 try:
     from arches.settings import *
@@ -154,7 +151,7 @@ INSTALLED_APPS = (
 )
 
 # arches_version==9.0.0
-if arches_version >= Version("8.0"):
+if arches_version >= (8, 0):
     INSTALLED_APPS += (
         "django_recaptcha",
         "pgtrigger",

--- a/arches_querysets/utils/models.py
+++ b/arches_querysets/utils/models.py
@@ -19,10 +19,7 @@ from django.db.models.fields.json import KT
 from django.http import HttpRequest
 from django.utils.functional import cached_property
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.models.models import ResourceInstance, TileModel
 
 from arches_querysets.datatypes.datatypes import DataTypeFactory
@@ -184,7 +181,7 @@ def get_nodegroups_here_and_below(start_nodegroup):
         nonlocal accumulator
         accumulator.append(nodegroup)
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             children_attr = nodegroup.children
         else:
             children_attr = nodegroup.nodegroup_set

--- a/arches_querysets/utils/tests.py
+++ b/arches_querysets/utils/tests.py
@@ -4,10 +4,7 @@ import uuid
 from django.db.models import F, OuterRef, prefetch_related_objects
 from django.test import TestCase
 
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.models.graph import Graph
 from arches.app.models.models import (
     CardModel,
@@ -46,7 +43,7 @@ class GraphTestCase(TestCase):
 
         graph_proxy = Graph.objects.get(pk=cls.graph.pk)
         # arches_version==9.0.0
-        if arches_version < Version("8.0"):
+        if arches_version < (8, 0):
             graph_proxy.refresh_from_database()
             # Repair parent nodegroup link broken by get_nodegroups()!
             for node in graph_proxy.nodes.values():
@@ -72,7 +69,7 @@ class GraphTestCase(TestCase):
             name="Datatype Lookups", is_resource=True
         )
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             cls.graph.is_active = True
             cls.graph.save()
         cls.root_node = cls.graph.node_set.get(istopnode=True)
@@ -88,7 +85,7 @@ class GraphTestCase(TestCase):
             parentnodegroup=parent_nodegroup,
         )
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             nodegroup.grouping_node = grouping_node
             nodegroup.save()
         grouping_node.nodegroup = nodegroup
@@ -225,7 +222,7 @@ class GraphTestCase(TestCase):
             "number": 7,
             "date": (
                 "1979-10-12"
-                if arches_version > Version("8.0")
+                if arches_version > (8, 0)
                 else "1979-10-12T00:00:00.000-05:00"
             ),
             # "resource-instance": None,
@@ -251,15 +248,15 @@ class GraphTestCase(TestCase):
                 else:
                     raise RuntimeError("Missing datatype")
             # arches_version==9.0.0
-            if arches_version < Version("8.0"):
+            if arches_version < (8, 0):
                 widget.save()
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             CardXNodeXWidget.objects.bulk_update(node_widgets, ["config"])
 
     @classmethod
     def create_resources(cls):
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             from arches.app.models.models import ResourceInstanceLifecycleState
 
             state = ResourceInstanceLifecycleState.objects.first()
@@ -278,7 +275,7 @@ class GraphTestCase(TestCase):
         }
 
         # arches_version==9.0.0
-        if arches_version >= Version("8.0"):
+        if arches_version >= (8, 0):
             resource_with_data_kwargs["resource_instance_lifecycle_state"] = state
             resource_without_data_kwargs["resource_instance_lifecycle_state"] = state
 
@@ -408,7 +405,7 @@ class GraphTestCase(TestCase):
     @classmethod
     def create_relations(cls):
         # arches_version==9.0.0
-        if arches_version < Version("8.0"):
+        if arches_version < (8, 0):
             from_resource_attr = "resourceinstanceidto"
             to_resource_attr = "resourceinstanceidfrom"
             from_graph_attr = "resourceinstancefrom_graphid"

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -5,10 +5,7 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 from django.urls import reverse
-from arches import __version__ as _arches_version_str
-from packaging.version import Version
-
-arches_version = Version(_arches_version_str)
+from arches import VERSION as arches_version
 from arches.app.models.graph import Graph
 from arches.app.models.models import EditLog
 
@@ -229,7 +226,7 @@ class RestFrameworkTests(GraphTestCase):
             },
         )
 
-    @unittest.skipIf(arches_version < Version("8.0"), reason="Arches 8+ only logic")
+    @unittest.skipIf(arches_version < (8, 0), reason="Arches 8+ only logic")
     def test_out_of_date_resource(self):
         Graph.objects.get(pk=self.graph.pk).publish(user=None)
 


### PR DESCRIPTION
Not very urgent, since 8.1 is coming out soon, but given we added the VERSION tuple back in https://github.com/archesproject/arches/commit/0b5ae1941998eccc22aebd78b81eaeea02b9013b, I figured we can adhere to the pattern that will support dev versions next time?

This reverts commit ab1ff215654506d7a52f8b4c2f66b50f62fd9cea.