### PR TITLE
fixes file list upload for existing tiles

### DIFF
--- a/arches_querysets/bulk_operations/tiles.py
+++ b/arches_querysets/bulk_operations/tiles.py
@@ -277,6 +277,9 @@ class TileTreeOperation:
                     ),
                     "parenttile_id": existing_tile.parenttile_id,
                 }
+                # Deserializing new_tile doesn't set nodegroup_id; new child
+                # tiles inserted under it need it set as their parenttile.
+                new_tile.nodegroup_id = grouping_node.nodegroup_id
                 existing_tile._incoming_tile = new_tile
                 if new_tile.sortorder is not None:
                     existing_tile.sortorder = new_tile.sortorder

--- a/arches_querysets/datatypes/file.py
+++ b/arches_querysets/datatypes/file.py
@@ -30,6 +30,12 @@ class FileListDataType(datatypes.FileListDataType):
             languages = models.Language.objects.all()
         language = get_language()
         original_value = value
+        reset_fabricated_ids = "bulk_import" not in kwargs
+        # Entries to undo the phantom file/file_id fabricated below for
+        # genuinely new entries (no file_id in the original payload), so
+        # post_tile_save can link the real upload.
+        fabricated_file_dicts = []
+
         # arches == 9.0.0 - remove the stringifieid_list in favor of the 8.1.0 logic
         if arches_version < Version("8.1"):
             if isinstance(value, str):
@@ -47,35 +53,41 @@ class FileListDataType(datatypes.FileListDataType):
             )
             new_value = []
             for file in value:
-                if not isinstance(original_value, str):
-                    matching_file_info = next(
-                        (
-                            file_dict
-                            for file_dict in original_value
-                            if file_dict.get("name") == file.get("name")
-                        ),
-                        None,
-                    )
-                    if matching_file_info:
-                        new_value.append({**matching_file_info, **file})
-                else:
+                if isinstance(original_value, str):
                     new_value.append(file)
+                    continue
+
+                matching_file_info = next(
+                    (
+                        file_dict
+                        for file_dict in original_value
+                        if file_dict.get("name") == file.get("name")
+                    ),
+                    None,
+                )
+                if not matching_file_info:
+                    continue
+
+                if matching_file_info.get("file_id"):
+                    merged_file_info = {**file, **matching_file_info}
+                else:
+                    merged_file_info = {**matching_file_info, **file}
+                    if reset_fabricated_ids:
+                        fabricated_file_dicts.append(merged_file_info)
+                new_value.append(merged_file_info)
         else:
             new_value = super().transform_value_for_tile(
                 value, languages=languages, **kwargs
             )
 
-        # Undo the phantom file/file_id fabricated above for genuinely new
-        # entries ( no file_id in the original payload ), so post_tile_save
-        # can link the real upload.
-        if "bulk_import" not in kwargs:
-            # Can't align positionally; skip rather than risk deleting a
-            # File row we can't positively identify as brand-new.
-            new_file_dicts = []
-            if isinstance(original_value, list) and len(original_value) == len(
-                new_value
+            # If lengths ever diverge we can't align by position; skip the
+            # reset rather than risk deleting the wrong File row.
+            if (
+                reset_fabricated_ids
+                and isinstance(original_value, list)
+                and len(original_value) == len(new_value)
             ):
-                new_file_dicts = [
+                fabricated_file_dicts = [
                     file_dict
                     for original_entry, file_dict in zip(original_value, new_value)
                     if not (
@@ -84,13 +96,13 @@ class FileListDataType(datatypes.FileListDataType):
                     )
                 ]
 
-            if new_file_dicts:
-                File.objects.filter(
-                    fileid__in=[file_dict["file_id"] for file_dict in new_file_dicts]
-                ).delete()
-                for file_dict in new_file_dicts:
-                    file_dict["file_id"] = None
-                    file_dict["url"] = None
+        if fabricated_file_dicts:
+            File.objects.filter(
+                fileid__in=[file_dict["file_id"] for file_dict in fabricated_file_dicts]
+            ).delete()
+            for file_dict in fabricated_file_dicts:
+                file_dict["file_id"] = None
+                file_dict["url"] = None
 
         for file_info in new_value:
             for key, val in file_info.items():

--- a/arches_querysets/datatypes/file.py
+++ b/arches_querysets/datatypes/file.py
@@ -35,6 +35,7 @@ class FileListDataType(datatypes.FileListDataType):
         # genuinely new entries (no file_id in the original payload), so
         # post_tile_save can link the real upload.
         fabricated_file_dicts = []
+        file_ids_to_delete = []
 
         # arches == 9.0.0 - remove the stringifieid_list in favor of the 8.1.0 logic
         if arches_version < Version("8.1"):
@@ -70,8 +71,17 @@ class FileListDataType(datatypes.FileListDataType):
 
                 if matching_file_info.get("file_id"):
                     merged_file_info = {**file, **matching_file_info}
+                    phantom_file_id = file.get("file_id")
+
+                    if (
+                        reset_fabricated_ids
+                        and phantom_file_id
+                        and phantom_file_id != matching_file_info["file_id"]
+                    ):
+                        file_ids_to_delete.append(phantom_file_id)
                 else:
                     merged_file_info = {**matching_file_info, **file}
+
                     if reset_fabricated_ids:
                         fabricated_file_dicts.append(merged_file_info)
                 new_value.append(merged_file_info)
@@ -96,13 +106,15 @@ class FileListDataType(datatypes.FileListDataType):
                     )
                 ]
 
-        if fabricated_file_dicts:
-            File.objects.filter(
-                fileid__in=[file_dict["file_id"] for file_dict in fabricated_file_dicts]
-            ).delete()
-            for file_dict in fabricated_file_dicts:
-                file_dict["file_id"] = None
-                file_dict["url"] = None
+        file_ids_to_delete.extend(
+            file_dict["file_id"] for file_dict in fabricated_file_dicts
+        )
+        if file_ids_to_delete:
+            File.objects.filter(fileid__in=file_ids_to_delete).delete()
+
+        for file_dict in fabricated_file_dicts:
+            file_dict["file_id"] = None
+            file_dict["url"] = None
 
         for file_info in new_value:
             for key, val in file_info.items():

--- a/arches_querysets/datatypes/file.py
+++ b/arches_querysets/datatypes/file.py
@@ -29,9 +29,9 @@ class FileListDataType(datatypes.FileListDataType):
         if not languages:  # pragma: no cover
             languages = models.Language.objects.all()
         language = get_language()
+        original_value = value
         # arches == 9.0.0 - remove the stringifieid_list in favor of the 8.1.0 logic
         if arches_version < Version("8.1"):
-            original_value = value
             if isinstance(value, str):
                 stringified_list = value
             elif isinstance(value, list) and all(
@@ -65,19 +65,32 @@ class FileListDataType(datatypes.FileListDataType):
                 value, languages=languages, **kwargs
             )
 
-        # Remove file object created in transform_value_for_tile
-        # after discussion with chiatt, this behavior is only really needed
-        # for the bulk loader (and causes integrity problems/duplicity) -
-        # file will be recreated later in post_tile_save.  Skip this deletion
-        if "bulk_import" not in kwargs and (
-            "is_existing_tile" not in kwargs or not kwargs["is_existing_tile"]
-        ):
-            File.objects.filter(
-                fileid__in=[file["file_id"] for file in new_value]
-            ).delete()
-            for file_dict in new_value:
-                file_dict["file_id"] = None
-                file_dict["url"] = None
+        # Undo the phantom file/file_id fabricated above for genuinely new
+        # entries ( no file_id in the original payload ), so post_tile_save
+        # can link the real upload.
+        if "bulk_import" not in kwargs:
+            # Can't align positionally; skip rather than risk deleting a
+            # File row we can't positively identify as brand-new.
+            new_file_dicts = []
+            if isinstance(original_value, list) and len(original_value) == len(
+                new_value
+            ):
+                new_file_dicts = [
+                    file_dict
+                    for original_entry, file_dict in zip(original_value, new_value)
+                    if not (
+                        isinstance(original_entry, dict)
+                        and original_entry.get("file_id")
+                    )
+                ]
+
+            if new_file_dicts:
+                File.objects.filter(
+                    fileid__in=[file_dict["file_id"] for file_dict in new_file_dicts]
+                ).delete()
+                for file_dict in new_file_dicts:
+                    file_dict["file_id"] = None
+                    file_dict["url"] = None
 
         for file_info in new_value:
             for key, val in file_info.items():

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1,5 +1,4 @@
 import json
-import uuid
 from unittest.mock import Mock, patch
 
 from packaging.version import Version
@@ -487,11 +486,19 @@ class DatatypeMethodTests(GraphTestCase):
         pre_existing_file = File.objects.create(path="uploadedfiles/existing.jpg")
         datatype_instance = self.datatype_factory.get_instance(datatype="file-list")
 
+        # The real base class persists a fresh File row for every name in
+        # the stringified list it's given, even ones that already have one.
+        phantom_new_file = File.objects.create(path="uploadedfiles/new-photo.jpg")
+        phantom_existing_file = File.objects.create(path="uploadedfiles/existing.jpg")
         reordered_base_output = [
-            {"name": "new-photo.jpg", "file_id": str(uuid.uuid4()), "url": "/fake"},
+            {
+                "name": "new-photo.jpg",
+                "file_id": str(phantom_new_file.pk),
+                "url": "/fake",
+            },
             {
                 "name": "existing.jpg",
-                "file_id": str(uuid.uuid4()),
+                "file_id": str(phantom_existing_file.pk),
                 "url": "/fake",
             },
         ]
@@ -519,4 +526,9 @@ class DatatypeMethodTests(GraphTestCase):
         by_name = {entry["name"]: entry for entry in transformed_value}
         self.assertEqual(by_name["existing.jpg"]["file_id"], str(pre_existing_file.pk))
         self.assertIsNone(by_name["new-photo.jpg"]["file_id"])
+
+        # Only the real, pre-existing File row survives; both phantom rows
+        # the base class fabricated (for the existing entry and the new
+        # one) are cleaned up.
         self.assertTrue(File.objects.filter(pk=pre_existing_file.pk).exists())
+        self.assertEqual(File.objects.count(), 1)

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1,5 +1,8 @@
 import json
-from unittest.mock import Mock
+import uuid
+from unittest.mock import Mock, patch
+
+from packaging.version import Version
 
 from arches.app.models.models import File
 
@@ -477,3 +480,43 @@ class DatatypeMethodTests(GraphTestCase):
 
         self.assertTrue(File.objects.filter(pk=pre_existing_file.pk).exists())
         self.assertEqual(File.objects.count(), 1)
+
+    def test_transform_value_for_tile_mixed_files_on_existing_tile_pre_8_1(self):
+        # Pre-8.1, the base class reconstructs entries by name, not
+        # position, so the reset must not assume matching order.
+        pre_existing_file = File.objects.create(path="uploadedfiles/existing.jpg")
+        datatype_instance = self.datatype_factory.get_instance(datatype="file-list")
+
+        reordered_base_output = [
+            {"name": "new-photo.jpg", "file_id": str(uuid.uuid4()), "url": "/fake"},
+            {
+                "name": "existing.jpg",
+                "file_id": str(uuid.uuid4()),
+                "url": "/fake",
+            },
+        ]
+
+        with (
+            patch("arches_querysets.datatypes.file.arches_version", Version("8.0.99")),
+            patch(
+                "arches.app.datatypes.datatypes.FileListDataType"
+                ".transform_value_for_tile",
+                return_value=reordered_base_output,
+            ),
+        ):
+            transformed_value = datatype_instance.transform_value_for_tile(
+                [
+                    {
+                        "name": "existing.jpg",
+                        "file_id": str(pre_existing_file.pk),
+                        "url": f"/files/{pre_existing_file.pk}",
+                    },
+                    {"name": "new-photo.jpg", "type": "image/jpeg"},
+                ],
+                is_existing_tile=True,
+            )
+
+        by_name = {entry["name"]: entry for entry in transformed_value}
+        self.assertEqual(by_name["existing.jpg"]["file_id"], str(pre_existing_file.pk))
+        self.assertIsNone(by_name["new-photo.jpg"]["file_id"])
+        self.assertTrue(File.objects.filter(pk=pre_existing_file.pk).exists())

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -1,6 +1,8 @@
 import json
 from unittest.mock import Mock
 
+from arches.app.models.models import File
+
 from arches_querysets.models import ResourceTileTree
 from arches_querysets.utils.tests import GraphTestCase
 
@@ -435,3 +437,43 @@ class DatatypeMethodTests(GraphTestCase):
                         )
                     else:
                         self.assertEqual(transformed_value, value["output"])
+
+    def test_transform_value_for_tile_new_file_on_existing_tile(self):
+        datatype_instance = self.datatype_factory.get_instance(datatype="file-list")
+
+        transformed_value = datatype_instance.transform_value_for_tile(
+            [{"name": "new-photo.jpg", "type": "image/jpeg"}],
+            is_existing_tile=True,
+        )
+
+        self.assertEqual(len(transformed_value), 1)
+        self.assertIsNone(transformed_value[0]["file_id"])
+        self.assertIsNone(transformed_value[0]["url"])
+        self.assertEqual(File.objects.count(), 0)
+
+    def test_transform_value_for_tile_mixed_files_on_existing_tile(self):
+        pre_existing_file = File.objects.create(path="uploadedfiles/existing.jpg")
+        datatype_instance = self.datatype_factory.get_instance(datatype="file-list")
+
+        transformed_value = datatype_instance.transform_value_for_tile(
+            [
+                {
+                    "name": "existing.jpg",
+                    "file_id": str(pre_existing_file.pk),
+                    "url": f"/files/{pre_existing_file.pk}",
+                },
+                {"name": "new-photo.jpg", "type": "image/jpeg"},
+            ],
+            is_existing_tile=True,
+        )
+
+        self.assertEqual(len(transformed_value), 2)
+
+        self.assertEqual(transformed_value[0]["file_id"], str(pre_existing_file.pk))
+        self.assertEqual(transformed_value[0]["url"], f"/files/{pre_existing_file.pk}")
+
+        self.assertIsNone(transformed_value[1]["file_id"])
+        self.assertIsNone(transformed_value[1]["url"])
+
+        self.assertTrue(File.objects.filter(pk=pre_existing_file.pk).exists())
+        self.assertEqual(File.objects.count(), 1)

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -1,16 +1,21 @@
+import json
+import tempfile
 import unittest
 import uuid
 from http import HTTPStatus
 from unittest.mock import patch
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.management import call_command
+from django.test import override_settings
+from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
 from django.urls import reverse
 from arches import __version__ as _arches_version_str
 from packaging.version import Version
 
 arches_version = Version(_arches_version_str)
 from arches.app.models.graph import Graph
-from arches.app.models.models import EditLog
+from arches.app.models.models import EditLog, File, Node, NodeGroup
 
 from arches_querysets.rest_framework.serializers import (
     ArchesResourceSerializer,
@@ -908,6 +913,112 @@ class RestFrameworkTests(GraphTestCase):
             "put-n-1-child",
             "Card-1 child must be fresh in resource PUT update response (n→1)",
         )
+
+    def test_client_supplied_tileid_survives_new_cardinality_n_tile_via_resource_put(
+        self,
+    ):
+        client_tileid = str(uuid.uuid4())
+        update_url = reverse(
+            "arches_querysets:api-resource",
+            kwargs={"graph": "datatype_lookups", "pk": str(self.resource_42.pk)},
+        )
+        request_body = {
+            "aliased_data": {
+                "datatypes_n": [
+                    {
+                        "tileid": client_tileid,
+                        "aliased_data": {"string_alias_n": "verify_tileid_value"},
+                    }
+                ],
+            },
+        }
+        self.client.login(username="dev", password="dev")
+        response = self.client.put(
+            update_url, request_body, content_type="application/json"
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+        new_tiles = response.json()["aliased_data"]["datatypes_n"]
+        matching = [
+            new_tile
+            for new_tile in new_tiles
+            if new_tile["aliased_data"]["string_alias_n"]["node_value"]["en"]["value"]
+            == "verify_tileid_value"
+        ]
+        self.assertEqual(len(matching), 1)
+        self.assertEqual(matching[0]["tileid"], client_tileid)
+
+    def test_update_tile_with_new_file_upload_on_existing_tile(self):
+        with override_settings(MEDIA_ROOT=tempfile.mkdtemp()):
+            file_node_id = str(
+                Node.objects.get(graph=self.graph, alias="file_list_alias").pk
+            )
+            pre_existing_file = File.objects.create(path="uploadedfiles/existing.jpg")
+
+            update_url = reverse(
+                "arches_querysets:api-tile",
+                kwargs={
+                    "graph": "datatype_lookups",
+                    "nodegroup_alias": "datatypes_1",
+                    "pk": self.resource_42.aliased_data.datatypes_1.pk,
+                },
+            )
+            request_body = {
+                "aliased_data": {
+                    "file_list_alias": [
+                        {
+                            "name": "existing.jpg",
+                            "file_id": str(pre_existing_file.pk),
+                            "url": f"/files/{pre_existing_file.pk}",
+                        },
+                        {"name": "new_photo.jpg", "type": "image/jpeg"},
+                    ],
+                },
+                "resourceinstance": str(self.resource_42.pk),
+            }
+            encoded_body = encode_multipart(
+                BOUNDARY,
+                {
+                    "json": json.dumps(request_body),
+                    f"file-list_{file_node_id}": SimpleUploadedFile(
+                        "new_photo.jpg", b"fake-image-bytes", content_type="image/jpeg"
+                    ),
+                },
+            )
+
+            self.client.login(username="dev", password="dev")
+            response = self.client.patch(
+                update_url, encoded_body, content_type=MULTIPART_CONTENT
+            )
+
+            self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
+            updated_files = response.json()["aliased_data"]["file_list_alias"][
+                "node_value"
+            ]
+            self.assertEqual(len(updated_files), 2)
+
+            existing_entry = next(
+                file_entry
+                for file_entry in updated_files
+                if file_entry["name"] == "existing.jpg"
+            )
+            new_entry = next(
+                file_entry
+                for file_entry in updated_files
+                if file_entry["name"] == "new_photo.jpg"
+            )
+
+            # The pre-existing entry and its File row are untouched.
+            self.assertEqual(existing_entry["file_id"], str(pre_existing_file.pk))
+            self.assertTrue(File.objects.filter(pk=pre_existing_file.pk).exists())
+
+            # The new upload is linked to a real File row with the uploaded
+            # content, not left pointing at a phantom/nonexistent file.
+            self.assertIsNotNone(new_entry["file_id"])
+            new_file_model = File.objects.get(pk=new_entry["file_id"])
+            self.assertEqual(new_file_model.path.read(), b"fake-image-bytes")
+
+            # No orphans: exactly the pre-existing File row plus the new one.
+            self.assertEqual(File.objects.count(), 2)
 
     @unittest.skipIf(arches_version < Version("8.0"), reason="Arches 8+ only logic")
     def test_out_of_date_resource(self):

--- a/tests/test_rest_framework.py
+++ b/tests/test_rest_framework.py
@@ -918,18 +918,28 @@ class RestFrameworkTests(GraphTestCase):
         self,
     ):
         client_tileid = str(uuid.uuid4())
+        parent_tile = self.resource_42.aliased_data.datatypes_1
         update_url = reverse(
             "arches_querysets:api-resource",
             kwargs={"graph": "datatype_lookups", "pk": str(self.resource_42.pk)},
         )
         request_body = {
             "aliased_data": {
-                "datatypes_n": [
-                    {
-                        "tileid": client_tileid,
-                        "aliased_data": {"string_alias_n": "verify_tileid_value"},
-                    }
-                ],
+                "datatypes_1": {
+                    "tileid": str(parent_tile.pk),
+                    "resourceinstance": str(self.resource_42.pk),
+                    "aliased_data": {
+                        "datatypes_1_n_child": [
+                            {
+                                "tileid": client_tileid,
+                                "resourceinstance": str(self.resource_42.pk),
+                                "aliased_data": {
+                                    "non_localized_string_alias_1_n_child": "verify_tileid_value"
+                                },
+                            }
+                        ],
+                    },
+                },
             },
         }
         self.client.login(username="dev", password="dev")
@@ -937,11 +947,17 @@ class RestFrameworkTests(GraphTestCase):
             update_url, request_body, content_type="application/json"
         )
         self.assertEqual(response.status_code, HTTPStatus.OK, response.content)
-        new_tiles = response.json()["aliased_data"]["datatypes_n"]
+
+        def _nv(v):
+            return v["node_value"] if isinstance(v, dict) else v
+
+        new_children = response.json()["aliased_data"]["datatypes_1"]["aliased_data"][
+            "datatypes_1_n_child"
+        ]
         matching = [
-            new_tile
-            for new_tile in new_tiles
-            if new_tile["aliased_data"]["string_alias_n"]["node_value"]["en"]["value"]
+            child
+            for child in new_children
+            if _nv(child["aliased_data"]["non_localized_string_alias_1_n_child"])
             == "verify_tileid_value"
         ]
         self.assertEqual(len(matching), 1)


### PR DESCRIPTION
Uploading a new file onto a tile that already exists was leaving the file orphaned instead of linking it. Transform_value_for_tile was resetting fabricated file_id/url per-tile instead of per-entry. 

Also found a nodegroup_id bug: new child tiles nested under an updated parent were failing parenttile validation so passed it through